### PR TITLE
Fix? white space removal from concatenated values

### DIFF
--- a/AEXML.swift
+++ b/AEXML.swift
@@ -269,8 +269,8 @@ private class AEXMLParser: NSObject, NSXMLParserDelegate {
     }
     
     func parser(parser: NSXMLParser, foundCharacters string: String) {
-        currentValue += string.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
-        currentElement?.value = currentValue
+        currentValue += string
+        currentElement?.value = currentValue.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
     }
     
     func parser(parser: NSXMLParser!, didEndElement elementName: String!, namespaceURI: String!, qualifiedName qName: String!) {


### PR DESCRIPTION
I had some issue with the parser removing white spaces where it should not. I finally found that line 272 was responsible for it.

I ended up simply moving the stringByTrimmingChars method and I got correct results.

I'm not sure if this can change other behaviors and I'll just leave this here and let you merge it if it's safe!

Here's my StackOverflow question about the issue:
http://stackoverflow.com/questions/27334458/swift-xml-parser-randomly-remove-white-spaces/27339076#27339076
