### PR TITLE
Added basic escaping of the five XML special characters

### DIFF
--- a/AEXML.swift
+++ b/AEXML.swift
@@ -38,6 +38,21 @@ public class AEXMLElement {
     public var stringValue: String {
         return value ?? String()
     }
+    public var escapedStringValue: String {
+        
+        // we need to make sure "&" is escaped first. Not doing this may break escaping the other characters
+        var escapedString = stringValue.stringByReplacingOccurrencesOfString("&", withString: "&amp;", options: NSStringCompareOptions.LiteralSearch, range: nil)
+        
+        let escapeChars = ["<" : "&lt;", ">" : "&gt;", "\"" : "&quot;", "'" : "&apos;"]
+
+        // replace the other four special characters
+        for (char, echar) in escapeChars {
+            escapedString = escapedString.stringByReplacingOccurrencesOfString(char, withString: echar, options: NSStringCompareOptions.LiteralSearch, range: nil)
+        }
+        
+        return escapedString
+    
+    }
     public var boolValue: Bool {
         return stringValue.lowercaseString == "true" || stringValue.toInt() == 1 ? true : false
     }
@@ -183,7 +198,7 @@ public class AEXMLElement {
                 xml += "</\(name)>"
             } else {
                 // insert string value and close element
-                xml += ">\(stringValue)</\(name)>"
+                xml += ">\(escapedStringValue)</\(name)>"
             }
         }
         


### PR DESCRIPTION
Added basic escaping of the five characters that need to be escaped in XML: ampersand, single quote, double quote, less than, greater than. If these characters are not escaped, the value of the xmlstring property can be invalid XML if only one of these characters is found in an element. The escaping could be further improved by also supporting attributes and line breaks in attributes.