### PR TITLE
Fixed memory leak in computed property xmlString

### DIFF
--- a/AEXML/AEXML.swift
+++ b/AEXML/AEXML.swift
@@ -164,7 +164,7 @@ public class AEXMLElement {
         if attributes.count > 0 {
             // insert attributes
             for att in attributes {
-                xml += " \(att.0.description)=\"\(att.1.description)\""
+                xml += " \(att.0)=\"\(att.1)\""
             }
         }
         


### PR DESCRIPTION
I found a memory leak in the computed property xmlString:

![bildschirmfoto 2015-05-07 um 10 23 16](https://cloud.githubusercontent.com/assets/12292178/7511560/00533618-f4a6-11e4-91cd-3408c5982da3.png)

This pull request resolves this issue ;)