### PR TITLE
Add OS X support to podspec

### DIFF
--- a/AEXML.podspec
+++ b/AEXML.podspec
@@ -11,4 +11,5 @@ s.social_media_url = 'http://twitter.com/tadija'
 s.source = { :git => 'https://github.com/tadija/AEXML.git', :tag => s.version }
 s.source_files = 'AEXML/*.swift'
 s.ios.deployment_target = '8.0'
+s.osx.deployment_target = '10.10'
 end


### PR DESCRIPTION
Also added a trailing newline to the podspec file. I have not submitted this to CocoaPods, but it passes `pod spec lint` with no warnings. You’ll want to bump the podspec version yourself. Thanks!