### PR TITLE
Make AEXMLElement.attributes mutable

### DIFF
--- a/AEXML/AEXML.swift
+++ b/AEXML/AEXML.swift
@@ -53,7 +53,7 @@ public class AEXMLElement: Equatable {
     
     public let name: String
     public var value: String?
-    public private(set) var attributes: [NSObject : AnyObject]
+    public var attributes: [NSObject : AnyObject]
     
     public var stringValue: String {
         return value ?? String()


### PR DESCRIPTION
This PR makes the `attributes` dictionary on `AEXMLElement` changeable after the containing element has been created. I found this requirement to be very inconvenient, so I removed it.