### PR TITLE
Added shouldIncludeNamespaces property to AEXMLDocument 

### DIFF
--- a/AEXML.xcodeproj/project.pbxproj
+++ b/AEXML.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		8BFE78C519F0054200914487 /* AEXMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE78C419F0054200914487 /* AEXMLTests.swift */; };
 		8BFE78CF19F0056D00914487 /* AEXML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE78CE19F0056D00914487 /* AEXML.swift */; };
 		8BFE78D119F0080B00914487 /* plant_catalog.xml in Resources */ = {isa = PBXBuildFile; fileRef = 8BFE78D019F0080B00914487 /* plant_catalog.xml */; };
+		9775D9BB1BD6CB5F00D5A74A /* soap.xml in Resources */ = {isa = PBXBuildFile; fileRef = 9775D9BA1BD6CB5F00D5A74A /* soap.xml */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +46,7 @@
 		8BFE78C419F0054200914487 /* AEXMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEXMLTests.swift; sourceTree = "<group>"; };
 		8BFE78CE19F0056D00914487 /* AEXML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AEXML.swift; sourceTree = "<group>"; };
 		8BFE78D019F0080B00914487 /* plant_catalog.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = plant_catalog.xml; sourceTree = "<group>"; };
+		9775D9BA1BD6CB5F00D5A74A /* soap.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = soap.xml; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,9 +113,10 @@
 		8BFE78AC19F0054100914487 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				8BFE78AD19F0054100914487 /* Info.plist */,
 				8BE1053319F6A43000716C35 /* example.xml */,
+				8BFE78AD19F0054100914487 /* Info.plist */,
 				8BFE78D019F0080B00914487 /* plant_catalog.xml */,
+				9775D9BA1BD6CB5F00D5A74A /* soap.xml */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -216,6 +219,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9775D9BB1BD6CB5F00D5A74A /* soap.xml in Resources */,
 				8BE1053419F6A43000716C35 /* example.xml in Resources */,
 				8BFE78B419F0054100914487 /* Main.storyboard in Resources */,
 				8BFE78D119F0080B00914487 /* plant_catalog.xml in Resources */,

--- a/AEXMLExample/soap.xml
+++ b/AEXMLExample/soap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+
+<soap:Envelope
+    xmlns:soap="http://www.w3.org/2001/12/soap-envelope"
+    soap:encodingStyle="http://www.w3.org/2001/12/soap-encoding">
+    
+    <soap:Body>
+        <m:GetPrice xmlns:m="http://www.w3schools.com/prices">
+            <m:Item>Apples</m:Item>
+        </m:GetPrice>
+    </soap:Body>
+    
+</soap:Envelope>

--- a/AEXMLTests/AEXMLTests.swift
+++ b/AEXMLTests/AEXMLTests.swift
@@ -19,7 +19,7 @@ class AEXMLTests: XCTestCase {
     
     // MARK: - Helper
     
-    func readXMLFromFile(filename: String) -> AEXMLDocument {
+    func readXMLFromFile(filename: String, shouldIncludeNamespaces: Bool = true) -> AEXMLDocument {
         var xmlDocument = AEXMLDocument()
         
         // parse xml file
@@ -28,7 +28,8 @@ class AEXMLTests: XCTestCase {
             data = NSData(contentsOfFile: xmlPath)
         {
             do {
-                xmlDocument = try AEXMLDocument(xmlData: data)
+                xmlDocument = AEXMLDocument()
+                try xmlDocument.loadXMLData(data, shouldIncludeNamespaces: shouldIncludeNamespaces)
             } catch {
                 print("\(error)")
             }
@@ -293,6 +294,18 @@ class AEXMLTests: XCTestCase {
         self.measureBlock() {
             _ = self.plantsXML.xmlString
         }
+    }
+    
+    func testSoapWithNamespaces() {
+        let soapXML = readXMLFromFile("soap")
+        let item = soapXML.root["soap:Body"]["m:GetPrice"]["m:Item"].stringValue
+        XCTAssertEqual(item, "Apples")
+    }
+    
+    func testSoapWithoutNamespaces() {
+        let soapXML = readXMLFromFile("soap", shouldIncludeNamespaces: false)
+        let item = soapXML.root["Body"]["GetPrice"]["Item"].stringValue
+        XCTAssertEqual(item, "Apples")
     }
     
 }


### PR DESCRIPTION
I added a property to AEXMLDocument that can be set to exclude namespace from the parser.