### PR TITLE
Fixed deprecation warnings introduced in Swift 2.2

### DIFF
--- a/Source/AEXML.swift
+++ b/Source/AEXML.swift
@@ -164,7 +164,7 @@ public class AEXMLElement: NSObject {
             var countAttributes = 0
             for (key, value) in attributes {
                 if element.attributes[key] == value {
-                    countAttributes++
+                    countAttributes += 1
                 }
             }
             return countAttributes == attributes.count
@@ -216,7 +216,7 @@ public class AEXMLElement: NSObject {
         var count = 0
         var element = self
         while let parent = element.parent {
-            count++
+            count += 1
             element = parent
         }
         return count
@@ -226,7 +226,7 @@ public class AEXMLElement: NSObject {
         var indent = String()
         while count > 0 {
             indent += "\t"
-            count--
+            count -= 1
         }
         return indent
     }

--- a/Tests/AEXMLTests.swift
+++ b/Tests/AEXMLTests.swift
@@ -90,7 +90,7 @@ class AEXMLTests: XCTestCase {
     func testChildrenElements() {
         var count = 0
         for _ in exampleXML.root["cats"].children {
-            count++
+            count += 1
         }
         XCTAssertEqual(count, 4, "Should be able to iterate children elements")
     }
@@ -106,7 +106,7 @@ class AEXMLTests: XCTestCase {
         // iterate attributes
         var count = 0
         for _ in firstCatAttributes {
-            count++
+            count += 1
         }
         XCTAssertEqual(count, 2, "Should be able to iterate element attributes.")
         
@@ -178,7 +178,7 @@ class AEXMLTests: XCTestCase {
         if let cats = exampleXML.root["cats"]["cat"].all {
             for cat in cats {
                 XCTAssertNotNil(cat.parent, "Each child element should have its parent element.")
-                count++
+                count += 1
             }
         }
         XCTAssertEqual(count, 4, "Should be able to iterate all elements")
@@ -219,7 +219,7 @@ class AEXMLTests: XCTestCase {
         var count = 0
         if let tinnas = cats["cat"].allWithValue("Tinna") {
             for _ in tinnas {
-                count++
+                count += 1
             }
         }
         XCTAssertEqual(count, 2, "Should be able to return elements with given value.")
@@ -229,7 +229,7 @@ class AEXMLTests: XCTestCase {
         var count = 0
         if let bulls = exampleXML.root["dogs"]["dog"].allWithAttributes(["color" : "white"]) {
             for _ in bulls {
-                count++
+                count += 1
             }
         }
         XCTAssertEqual(count, 2, "Should be able to return elements with given attributes.")


### PR DESCRIPTION
Fixed deprecation warnings encountered with Xcode version 7.3 beta
2 (7D129n). Warnings are part of Swift language deprecations introduced
in Swift 2.2 in preparation for Swift 3.0. Since these changes are
backwards compatible with 2.0, it likely makes sense to adopt now.

Now compiles clean for all platforms. All tests pass for all platforms.