### PR TITLE
Remove 'var" from parameters of indentation function

### DIFF
--- a/Source/AEXML.swift
+++ b/Source/AEXML.swift
@@ -223,7 +223,8 @@ public class AEXMLElement: NSObject {
         return count
     }
     
-    private func indentation(var count: Int) -> String {
+    private func indentation(count: Int) -> String {
+        var count = count
         var indent = String()
         while count > 0 {
             indent += "\t"


### PR DESCRIPTION
'var" parameters are deprecated in Swift 2.2 and will be removed in Swift 3.0