### PR TITLE
Add ability to create and configure NSXMLParserOptions from another package

### DIFF
--- a/Source/AEXML.swift
+++ b/Source/AEXML.swift
@@ -289,9 +289,13 @@ public class AEXMLDocument: AEXMLElement {
     
     /// Default options used by NSXMLParser
     public struct NSXMLParserOptions {
-        var shouldProcessNamespaces = false
-        var shouldReportNamespacePrefixes = false
-        var shouldResolveExternalEntities = false
+        public var shouldProcessNamespaces = false
+        public var shouldReportNamespacePrefixes = false
+        public var shouldResolveExternalEntities = false
+        
+        public init() {
+            
+        }
     }
     
     // MARK: Properties


### PR DESCRIPTION
When I create AEXMLDocument object by the constructor, I can pass options struct to it, but I can't create it from any external package or change its default properties (`Error 'AEXMLDocument.NSXMLParserOptions' cannot be constructed because it has no accessible initializers`). This commit makes all NSXMLParserOptions properties public and creates public initializer