### PR TITLE
Return nil value from subscript when element was not found

### DIFF
--- a/Source/AEXML.swift
+++ b/Source/AEXML.swift
@@ -404,14 +404,17 @@ public class AEXMLDocument: AEXMLElement {
     // MARK: Override
     
     /// Override of `xmlString` property of `AEXMLElement` - it just inserts XML Document header at the beginning.
-    public override var xmlString: String {
-        var xml =  "<?xml version=\"\(version)\" encoding=\"\(encoding)\" standalone=\"\(standalone)\"?>\n"
-        for child in children {
-            xml += child.xmlString
-        }
-        return xml
-    }
-    
+	public override var xmlString: String {
+		var xml =  "<?xml version=\"\(version)\" encoding=\"\(encoding)\" standalone=\"\(standalone)\"?>"
+		if prettyPrint {
+			xml += "\n"
+		}
+		for child in children {
+			xml += child.xmlString
+		}
+		return xml
+	}
+	
 }
 
 // MARK: -

--- a/Source/AEXML.swift
+++ b/Source/AEXML.swift
@@ -232,7 +232,11 @@ public class AEXMLElement: NSObject {
         return indent
     }
 	
-	public var prettyPrint = true
+	public static var prettyPrint = true
+	
+	private var prettyPrint: Bool {
+		return AEXMLElement.prettyPrint
+	}
 	
     /// Complete hierarchy of `self` and `children` in **XML** escaped and formatted String
     public var xmlString: String {

--- a/Source/AEXML.swift
+++ b/Source/AEXML.swift
@@ -108,7 +108,7 @@ public class AEXMLElement: NSObject {
             return self
         } else {
             let filtered = children.filter { $0.name == key }
-            let errorElement = AEXMLElement(AEXMLElement.errorElementName, value: "element <\(key)> not found")
+            let errorElement = AEXMLElement(AEXMLElement.errorElementName, value: nil)
             return filtered.count > 0 ? filtered.first! : errorElement
         }
     }

--- a/Source/AEXML.swift
+++ b/Source/AEXML.swift
@@ -231,13 +231,17 @@ public class AEXMLElement: NSObject {
         }
         return indent
     }
-    
+	
+	public var prettyPrint = true
+	
     /// Complete hierarchy of `self` and `children` in **XML** escaped and formatted String
     public var xmlString: String {
         var xml = String()
         
         // open element
-        xml += indentation(parentsCount - 1)
+		if prettyPrint {
+			xml += indentation(parentsCount - 1)
+		}
         xml += "<\(name)"
         
         if attributes.count > 0 {
@@ -253,13 +257,21 @@ public class AEXMLElement: NSObject {
         } else {
             if children.count > 0 {
                 // add children
-                xml += ">\n"
+				xml += ">"
+				if prettyPrint {
+					xml += "\n"
+				}
                 for child in children {
-                    xml += "\(child.xmlString)\n"
+                    xml += "\(child.xmlString)"
+					if prettyPrint {
+						xml += "\n"
+					}
                 }
-                // add indentation
-                xml += indentation(parentsCount - 1)
-                xml += "</\(name)>"
+				if prettyPrint {
+					// add indentation
+					xml += indentation(parentsCount - 1)
+				}
+				xml += "</\(name)>"
             } else {
                 // insert string value and close element
                 xml += ">\(escapedStringValue)</\(name)>"


### PR DESCRIPTION
Hello @tadija,

Thanks for your great library! :+1: 

I read in your README:
> ```swift
// prints element <badexample> not found
print(xmlDoc["badexample"]["notexisting"].stringValue)
```

which is nice for debugging purposes. But I think would be nicer is to return a `nil` value instead of an error message. It would allow to do such things:
```swift
let name: String? = xmlDoc["name"].value
```
Here, if "name" tag is not present, name would be `nil` instead of "element <notexisting> not found" which I find more useful. For that `AEXMLElement` returned here would have the `AEXMLError` `name` and a `nil` `value`.

What do you think?

I made a small commit for you to check :)

Thanks!