### PR TITLE
Fix indentation size and method

### DIFF
--- a/AEXML.xcodeproj/project.pbxproj
+++ b/AEXML.xcodeproj/project.pbxproj
@@ -179,7 +179,10 @@
 				8BFE78AA19F0054100914487 /* Products */,
 				8B8C736E1CD816C100A4E197 /* Supporting Files */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
 		};
 		8BFE78AA19F0054100914487 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
According to current code, it seems to be preferred to indent with 4 spaces instead of a tab. This commit makes sure that this happens with any Xcode. Project setting will override user setting.