### PR TITLE
Fix Carthage build error

### DIFF
--- a/AEXML.xcodeproj/xcshareddata/xcschemes/AEXML OSX.xcscheme
+++ b/AEXML.xcodeproj/xcshareddata/xcschemes/AEXML OSX.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8B4A92AA1BDD54F50011F36F"

--- a/AEXML.xcodeproj/xcshareddata/xcschemes/AEXML iOS.xcscheme
+++ b/AEXML.xcodeproj/xcshareddata/xcschemes/AEXML iOS.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8B4A92981BDD4CEF0011F36F"

--- a/AEXML.xcodeproj/xcshareddata/xcschemes/AEXML tvOS.xcscheme
+++ b/AEXML.xcodeproj/xcshareddata/xcschemes/AEXML tvOS.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8B4A92CB1BDD5BB20011F36F"


### PR DESCRIPTION
Carthage is failing on update with `module 'AEXML' was not compiled for testing` - it appears to be building the test target when it shouldn’t.

I’ve disabled the test target for all actions except ‘Test’.