### PR TITLE
Added support for querying elements with specific attribute keys

### DIFF
--- a/Example/Resources/example.xml
+++ b/Example/Resources/example.xml
@@ -8,8 +8,8 @@
     </cats>
     <dogs>
         <dog breed="Bull Terrier" color="white">Villy</dog>
-        <dog breed="Bull Terrier" color="white">Spot</dog>
+        <dog breed="Bull Terrier" color="white" gender="male">Spot</dog>
         <dog breed="Golden Retriever" color="yellow">Betty</dog>
-        <dog breed="Miniature Schnauzer" color="black">Kika</dog>
+        <dog breed="Miniature Schnauzer" color="black" gender="female">Kika</dog>
     </dogs>
 </animals>

--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -154,6 +154,26 @@ open class AEXMLElement {
         return found
     }
     
+    /**
+     Returns all elements with given attributes.
+     
+     - parameter attributes: Array of Keys of attributes.
+     
+     - returns: Optional Array of found XML elements.
+     */
+    open func all(withAttributes attributes: [String]) -> [AEXMLElement]? {
+        let found = filter { (element) -> Bool in
+            var countAttributes = 0
+            for key in attributes {
+                if element.attributes[key] != nil {
+                    countAttributes += 1
+                }
+            }
+            return countAttributes == attributes.count
+        }
+        return found
+    }
+    
     // MARK: - XML Write
     
     /**

--- a/Tests/AEXMLTests/AEXMLTests.swift
+++ b/Tests/AEXMLTests/AEXMLTests.swift
@@ -304,6 +304,16 @@ class AEXMLTests: XCTestCase {
         XCTAssertEqual(count, 2, "Should be able to return elements with given attributes.")
     }
     
+    func testAllWithAttributeKeys() {
+        var count = 0
+        if let bulls = exampleDocument.root["dogs"]["dog"].all(withAttributes: ["gender"]) {
+            for _ in bulls {
+                count += 1
+            }
+        }
+        XCTAssertEqual(count, 2, "Should be able to return elements with given attribute keys.")
+    }
+    
     // MARK: - XML Write
     
     func testAddChild() {


### PR DESCRIPTION
Added support for querying elements with specific attribute keys without specifying what the values should be.

I have found this to be a useful feature when parsing XML. I hope it's useful for somebody else.