### PR TITLE
Adds optional element properties

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -64,9 +64,9 @@ open class AEXMLElement {
     /// Optional boolean representation of `value` property.
     open var optionalBool: Bool? {
         if let value = self.value {
-            if value.lowercased() == "true" || Int(string) == 1 {
+            if value.lowercased() == "true" || Int(value) == 1 {
                 return true
-            } else if value.lowercased() == "false" || Int(string) == 0 {
+            } else if value.lowercased() == "false" || Int(value) == 0 {
                 return false
             }
         }

--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -56,14 +56,14 @@ open class AEXMLElement {
     open var string: String { return value ?? String() }
     
     /// Optional string representation of `value` property
-    open var optionalString: String? { return value }
+    open var optionalString: String? { return self.value }
     
     /// Boolean representation of `value` property (if `value` is "true" or 1 this is `True`, otherwise `False`).
     open var bool: Bool { return string.lowercased() == "true" || Int(string) == 1 ? true : false }
     
     /// Optional boolean representation of `value` property.
     open var optionalBool: Bool? {
-        if let value = value {
+        if let value = self.value {
             if value.lowercased() == "true" || Int(string) == 1 {
                 return true
             } else if value.lowercased() == "false" || Int(string) == 0 {
@@ -78,7 +78,7 @@ open class AEXMLElement {
     
     /// Optional integer representation of `value` property.
     open var optionalInt: Int? {
-        if let value = value {
+        if let value = self.value {
             return Int(value)
         }
         return nil
@@ -89,7 +89,7 @@ open class AEXMLElement {
     
     /// Optional double representation of `value` property.
     open var optionalDouble: Double? {
-        if let value = value {
+        if let value = self.value {
             return Double(value)
         }
         return nil

--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -55,14 +55,45 @@ open class AEXMLElement {
     /// String representation of `value` property (if `value` is `nil` this is empty String).
     open var string: String { return value ?? String() }
     
+    /// Optional string representation of `value` property
+    open var optionalString: String? { return value }
+    
     /// Boolean representation of `value` property (if `value` is "true" or 1 this is `True`, otherwise `False`).
     open var bool: Bool { return string.lowercased() == "true" || Int(string) == 1 ? true : false }
+    
+    /// Optional boolean representation of `value` property.
+    open var optionalBool: Bool? {
+        if let value = value {
+            if value.lowercased() == "true" || Int(string) == 1 {
+                return true
+            } else if value.lowercased() == "false" || Int(string) == 0 {
+                return false
+            }
+        }
+        return nil
+    }
     
     /// Integer representation of `value` property (this is **0** if `value` can't be represented as Integer).
     open var int: Int { return Int(string) ?? 0 }
     
+    /// Optional integer representation of `value` property.
+    open var optionalInt: Int? {
+        if let value = value {
+            return Int(value)
+        }
+        return nil
+    }
+    
     /// Double representation of `value` property (this is **0.00** if `value` can't be represented as Double).
     open var double: Double { return Double(string) ?? 0.00 }
+    
+    /// Optional double representation of `value` property.
+    open var optionalDouble: Double? {
+        if let value = value {
+            return Double(value)
+        }
+        return nil
+    }
     
     // MARK: - Lifecycle
     


### PR DESCRIPTION
The existing convenience properties never return nil, even if the data is invalid. If you want to check data validity as you parse your XML, you can use these properties.