### PR TITLE
Tail parsing

### DIFF
--- a/AEXML.podspec
+++ b/AEXML.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 s.name = 'AEXML'
-s.version = '4.1.0'
+s.version = '4.2.0'
 s.license = { :type => 'MIT', :file => 'LICENSE' }
 s.summary = 'Simple and lightweight XML parser written in Swift'
 

--- a/AEXML.xcodeproj/project.pbxproj
+++ b/AEXML.xcodeproj/project.pbxproj
@@ -43,6 +43,9 @@
 		8B52A49C1D84AF640060C08D /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B52A49A1D84AF640060C08D /* Options.swift */; };
 		8B52A49D1D84AF640060C08D /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B52A49A1D84AF640060C08D /* Options.swift */; };
 		8B52A49E1D84AF640060C08D /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B52A49A1D84AF640060C08D /* Options.swift */; };
+		C33523E71EAE563700AF876A /* format.xml in Resources */ = {isa = PBXBuildFile; fileRef = C33523E51EAE563000AF876A /* format.xml */; };
+		C33523E81EAE571000AF876A /* format.xml in Resources */ = {isa = PBXBuildFile; fileRef = C33523E51EAE563000AF876A /* format.xml */; };
+		C33523E91EAE571500AF876A /* format.xml in Resources */ = {isa = PBXBuildFile; fileRef = C33523E51EAE563000AF876A /* format.xml */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,6 +96,7 @@
 		8BDEBA8C1AEC588700A12D92 /* AEXML.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = AEXML.podspec; sourceTree = "<group>"; };
 		8BFE78C319F0054200914487 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8BFE78C419F0054200914487 /* AEXMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AEXMLTests.swift; path = AEXMLTests/AEXMLTests.swift; sourceTree = "<group>"; };
+		C33523E51EAE563000AF876A /* format.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = format.xml; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,6 +167,7 @@
 		8B4A92E91BDD66680011F36F /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				C33523E51EAE563000AF876A /* format.xml */,
 				8B4A92EA1BDD66680011F36F /* example.xml */,
 				8B4A92EB1BDD66680011F36F /* plant_catalog.xml */,
 			);
@@ -487,6 +492,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C33523E71EAE563700AF876A /* format.xml in Resources */,
 				8B4A92EC1BDD66680011F36F /* example.xml in Resources */,
 				8B4A92F01BDD66680011F36F /* plant_catalog.xml in Resources */,
 			);
@@ -496,6 +502,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C33523E91EAE571500AF876A /* format.xml in Resources */,
 				8B4A92ED1BDD66680011F36F /* example.xml in Resources */,
 				8B4A92F11BDD66680011F36F /* plant_catalog.xml in Resources */,
 			);
@@ -512,6 +519,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C33523E81EAE571000AF876A /* format.xml in Resources */,
 				8B4A92EE1BDD66680011F36F /* example.xml in Resources */,
 				8B4A92F21BDD66680011F36F /* plant_catalog.xml in Resources */,
 			);

--- a/Example/AEXMLDemo/ViewController.swift
+++ b/Example/AEXMLDemo/ViewController.swift
@@ -44,13 +44,13 @@ class ViewController: UIViewController {
             }
             
             // prints Optional("Tinna") (first element)
-            print(xmlDoc.root["cats"]["cat"].value)
+            print(xmlDoc.root["cats"]["cat"].value ?? "Value was nil!")
             
             // prints Tinna (first element)
             print(xmlDoc.root["cats"]["cat"].string)
             
             // prints Optional("Kika") (last element)
-            print(xmlDoc.root["dogs"]["dog"].last?.value)
+            print(xmlDoc.root["dogs"]["dog"].last?.value ?? "Value was nil!")
             
             // prints Betty (3rd element)
             print(xmlDoc.root["dogs"].children[2].string)
@@ -97,7 +97,7 @@ class ViewController: UIViewController {
             print(xmlDoc.root["cats"]["cat"].xmlCompact)
             
             // prints Optional(AEXML.AEXMLError.elementNotFound)
-            print(xmlDoc["NotExistingElement"].error)
+            print(xmlDoc["NotExistingElement"].error ?? "Error was nil!")
         }
         catch {
             print("\(error)")

--- a/Example/Resources/format.xml
+++ b/Example/Resources/format.xml
@@ -1,0 +1,10 @@
+<animals>
+    <cats>
+        meow
+        <cat>Tinna</cat>
+    </cats>
+    <dogs>
+        <dog>Villy</dog>
+    </dogs>
+    woof
+</animals>

--- a/Example/Resources/format.xml
+++ b/Example/Resources/format.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <animals>
     <cats>
         meow

--- a/Sources/Document.swift
+++ b/Sources/Document.swift
@@ -99,4 +99,21 @@ open class AEXMLDocument: AEXMLElement {
         return xml
     }
     
+    /**
+     Complete hierarchy of document in an **XML** escaped String with the header at
+     the beginning.
+     
+     - parameters:
+        - trimWhiteSpace: Trim whitespace and newlines (defaults to `true`).
+        - format: Insert newlines and indentation between elements (defaults to `true`).
+     
+     - returns: XML document as a string.
+     */
+    open override func xmlString(trimWhiteSpace: Bool = true, format: Bool = true) -> String {
+        var xml = "\(options.documentHeader.xmlString)\n"
+        xml += root.xmlString(trimWhiteSpace: trimWhiteSpace, format: format)
+        
+        return xml
+    }
+    
 }

--- a/Sources/Document.swift
+++ b/Sources/Document.swift
@@ -100,17 +100,23 @@ open class AEXMLDocument: AEXMLElement {
     }
     
     /**
-     Complete hierarchy of document in an **XML** escaped String with the header at
-     the beginning.
-     
-     - parameters:
-        - trimWhiteSpace: Trim whitespace and newlines (defaults to `true`).
-        - format: Insert newlines and indentation between elements (defaults to `true`).
-     
-     - returns: XML document as a string.
+        Complete hierarchy of document in an **XML** escaped String with the header at
+        the beginning.
+        Trimming whitespace doesn't affect characters added by formatting.
+
+        - parameters:
+            - trimWhiteSpace: Trim whitespace and newlines (defaults to `true`).
+            - format: Insert newlines and indentation between elements (defaults to `true`).
+
+        - returns: XML document as a string.
      */
     open override func xmlString(trimWhiteSpace: Bool = true, format: Bool = true) -> String {
-        var xml = "\(options.documentHeader.xmlString)\n"
+        var xml = "\(options.documentHeader.xmlString)"
+        
+        if format || !trimWhiteSpace {
+            xml += "\n"
+        }
+        
         xml += root.xmlString(trimWhiteSpace: trimWhiteSpace, format: format)
         
         return xml

--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -22,6 +22,9 @@ open class AEXMLElement {
     /// XML Element value.
     open var value: String?
     
+    /// XML Element tail.
+    open var tail: String?
+    
     /// XML Element attributes.
     open var attributes: [String : String]
     
@@ -219,6 +222,8 @@ open class AEXMLElement {
             if children.count > 0 {
                 // add children
                 xml += ">\n"
+                xml += string.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).xmlEscaped
+                
                 for child in children {
                     xml += "\(child.xml)\n"
                 }
@@ -227,9 +232,52 @@ open class AEXMLElement {
                 xml += "</\(name)>"
             } else {
                 // insert string value and close element
+                xml += ">\(string.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).xmlEscaped)</\(name)>"
+            }
+        }
+        
+        // append the tail string if there is one
+        xml += tail?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).xmlEscaped ?? ""
+        
+        return xml
+    }
+    
+    /// Complete hierarchy of `self` and `children` in **XML** escaped String
+    open var xmlRaw: String {
+        var xml = String()
+        
+        // open element
+        xml += "<\(name)"
+        
+        if attributes.count > 0 {
+            // insert attributes
+            for (key, value) in attributes {
+                xml += " \(key)=\"\(value.xmlEscaped)\""
+            }
+        }
+        
+        if value == nil && children.count == 0 {
+            // close element
+            xml += " />"
+        } else {
+            if children.count > 0 {
+                // add children
+                xml += ">"
+                xml += string.xmlEscaped
+                
+                for child in children {
+                    xml += "\(child.xmlRaw)"
+                }
+                
+                xml += "</\(name)>"
+            } else {
+                // insert string value and close element
                 xml += ">\(string.xmlEscaped)</\(name)>"
             }
         }
+        
+        // append the tail string if there is one
+        xml += tail?.xmlEscaped ?? ""
         
         return xml
     }

--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -53,13 +53,15 @@ open class AEXMLElement {
     
         - parameter name: XML element name.
         - parameter value: XML element value (defaults to `nil`).
+        - parameter tail: XML element tail value (defaults to `nil`).
         - parameter attributes: XML element attributes (defaults to empty dictionary).
     
         - returns: An initialized `AEXMLElement` object.
     */
-    public init(name: String, value: String? = nil, attributes: [String : String] = [String : String]()) {
+    public init(name: String, value: String? = nil, tail: String? = nil, attributes: [String : String] = [String : String]()) {
         self.name = name
         self.value = value
+        self.tail = tail
         self.attributes = attributes
     }
     
@@ -156,15 +158,17 @@ open class AEXMLElement {
         
         - parameter name: Child XML element name.
         - parameter value: Child XML element value (defaults to `nil`).
+        - parameter tail: XML element tail value (defaults to `nil`).
         - parameter attributes: Child XML element attributes (defaults to empty dictionary).
         
         - returns: Child XML element with `self` as `parent`.
     */
     @discardableResult open func addChild(name: String,
                        value: String? = nil,
+                       tail: String? = nil,
                        attributes: [String : String] = [String : String]()) -> AEXMLElement
     {
-        let child = AEXMLElement(name: name, value: value, attributes: attributes)
+        let child = AEXMLElement(name: name, value: value, tail: tail, attributes: attributes)
         return addChild(child)
     }
     
@@ -248,6 +252,7 @@ open class AEXMLElement {
     
     /**
         Complete hierarchy of `self` and `children` in **XML** escaped String.
+        Trimming whitespace doesn't affect characters added by formatting.
         
         - parameters:
             - trimWhiteSpace: Trim whitespace and newlines (defaults to `true`).
@@ -258,8 +263,8 @@ open class AEXMLElement {
     open func xmlString(trimWhiteSpace: Bool = true, format: Bool = true) -> String {
         var xml = String()
         
-        let elementValue = trimWhiteSpace ? string.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines): string
-        let tailValue = trimWhiteSpace ? tailString.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines): tailString
+        let elementValue = trimWhiteSpace ? string.trimmed: string
+        let tailValue = trimWhiteSpace ? tailString.trimmed: tailString
         
         // open element
         xml += format ? indent(withDepth: parentsCount - 1) : ""
@@ -326,6 +331,11 @@ public extension String {
         }
         
         return escaped
+    }
+    
+    /// String value with whitespace and new lines trimmed
+    public var trimmed: String {
+        return trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
     }
     
 }

--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -34,6 +34,9 @@ open class AEXMLElement {
     /// String representation of `value` property (if `value` is `nil` this is empty String).
     open var string: String { return value ?? String() }
     
+    /// String representation of `tail` property (if `tail` is `nil` this is empty String).
+    open var tailString: String { return tail ?? String() }
+    
     /// Boolean representation of `value` property (`nil` if `value` can't be represented as Bool).
     open var bool: Bool? { return Bool(string) }
     
@@ -242,11 +245,24 @@ open class AEXMLElement {
         return xml
     }
     
-    /// Complete hierarchy of `self` and `children` in **XML** escaped String
-    open var xmlRaw: String {
+    
+    /**
+        Complete hierarchy of `self` and `children` in **XML** escaped String.
+        
+        - parameters:
+            - trimWhiteSpace: Trim whitespace and newlines (defaults to `true`).
+            - format: Insert newlines and indentation between elements (defaults to `true`).
+ 
+        - returns: XML hierarchy as a string.
+    */
+    open func xmlString(trimWhiteSpace: Bool = true, format: Bool = true) -> String {
         var xml = String()
         
+        let elementValue = trimWhiteSpace ? string.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines): string
+        let tailValue = trimWhiteSpace ? tailString.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines): tailString
+        
         // open element
+        xml += format ? indent(withDepth: parentsCount - 1) : ""
         xml += "<\(name)"
         
         if attributes.count > 0 {
@@ -256,28 +272,34 @@ open class AEXMLElement {
             }
         }
         
-        if value == nil && children.count == 0 {
+        if elementValue == String() && children.count == 0 {
             // close element
             xml += " />"
         } else {
             if children.count > 0 {
-                // add children
                 xml += ">"
-                xml += string.xmlEscaped
+                xml += format ? "\n" : ""
                 
+                // add value
+                xml += elementValue.xmlEscaped
+                // add children
                 for child in children {
-                    xml += "\(child.xmlRaw)"
+                    xml += child.xmlString(trimWhiteSpace: trimWhiteSpace, format: format)
+                    xml += format ? "\n" : ""
                 }
                 
+                xml += format ? indent(withDepth: parentsCount - 1) : ""
+                
+                // close element
                 xml += "</\(name)>"
             } else {
                 // insert string value and close element
-                xml += ">\(string.xmlEscaped)</\(name)>"
+                xml += ">\(elementValue.xmlEscaped)</\(name)>"
             }
         }
-        
+                
         // append the tail string if there is one
-        xml += tail?.xmlEscaped ?? ""
+        xml += tailValue.xmlEscaped
         
         return xml
     }

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -10,7 +10,6 @@ internal class AEXMLParser: NSObject, XMLParserDelegate {
     
     var currentParent: AEXMLElement?
     var currentElement: AEXMLElement?
-    var previousElement: AEXMLElement?
     var currentValue = String()
     
     var parseError: Error?
@@ -62,11 +61,8 @@ internal class AEXMLParser: NSObject, XMLParserDelegate {
         if let element = currentElement {
             // inside an element
             element.value = currentValue
-        } else if let previous = previousElement {
-            // outside an element and a previous is available
-            previous.tail = currentValue
         } else if let parent = currentParent {
-            // outside an element and there's no previous - get the parent's last
+            // outside an element - get the parent's last
             parent.children.last?.tail = currentValue
         }
     }

--- a/Tests/AEXMLTests/AEXMLTests.swift
+++ b/Tests/AEXMLTests/AEXMLTests.swift
@@ -340,6 +340,13 @@ class AEXMLTests: XCTestCase {
         }
     }
     
+    func testWhiteSpaceTrim() {
+        let expectedString = "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<animals><cats>meow<cat>Tinna</cat></cats><dogs><dog>Villy</dog></dogs>woof</animals>"
+        let xmlString = formatDocument.xmlString(trimWhiteSpace: true, format: false)
+        
+        XCTAssertEqual(xmlString, expectedString, "Should trim whitespace and newlines in XML string.")
+    }
+    
     // MARK: - XML Write
     
     func testAddChild() {

--- a/Tests/AEXMLTests/AEXMLTests.swift
+++ b/Tests/AEXMLTests/AEXMLTests.swift
@@ -326,7 +326,7 @@ class AEXMLTests: XCTestCase {
     
     func testXMLFormat() {
         // note: the test shouldn't include attributes as their order can differ and would make the strings differ
-        let rawOutputString = formatDocument.root.xmlRaw
+        let rawOutputString = formatDocument.root.xmlString(trimWhiteSpace: false, format: false)
         
         XCTAssertEqual(rawOutputString, formatXMLString, "Should output the same document format it loaded")
     }


### PR DESCRIPTION
This PR preserves strings (whitespace included) that may come after elements, similar to [this.](https://docs.python.org/2/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.tail)

**Summary:**

* Outputs a value of an element, even if it has children.
* Parses strings that come after closed elements and puts them in a tail string property
* Does not strip whitespace upon parsing
* Adds an xmlString() function for output
* Adds a "trimmed" string extension
* Adds tests for .xml and .xmlCompact parity with xmlString()