### PR TITLE
Add support to CDATA value

### DIFF
--- a/AEXML.podspec
+++ b/AEXML.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 s.name = 'AEXML'
-s.version = '4.1.0'
+s.version = '4.1.1'
 s.license = { :type => 'MIT', :file => 'LICENSE' }
 s.summary = 'Simple and lightweight XML parser written in Swift'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 4.1.1
+
+- Add support to CDATA values.
+
 ## Version 4.1.0
 
 - Convenience typed accessors are now optional instead of having default values

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -58,7 +58,7 @@ internal class AEXMLParser: NSObject, XMLParserDelegate {
     func parser(_ parser: XMLParser, foundCharacters string: String) {
         currentValue += string
         let newValue = currentValue.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-        currentElement?.value = newValue == String() ? nil : newValue
+        currentElement?.value = newValue == String() ? nil : AEXMLElementValue(plainValue: newValue)
     }
     
     func parser(_ parser: XMLParser,

--- a/Tests/AEXMLTests/AEXMLTests.swift
+++ b/Tests/AEXMLTests/AEXMLTests.swift
@@ -165,13 +165,13 @@ class AEXMLTests: XCTestCase {
     func testValue() {
         let firstPlant = plantsDocument.root["PLANT"]
         
-        let firstPlantCommon = firstPlant["COMMON"].value!
+        let firstPlantCommon = firstPlant["COMMON"].value!.string
         XCTAssertEqual(firstPlantCommon, "Bloodroot", "Should be able to return element value as optional string.")
         
-        let firstPlantElementWithoutValue = firstPlant["ELEMENTWITHOUTVALUE"].value
+        let firstPlantElementWithoutValue = firstPlant["ELEMENTWITHOUTVALUE"].value?.string
         XCTAssertNil(firstPlantElementWithoutValue, "Should be able to have nil value.")
         
-        let firstPlantEmptyElement = firstPlant["EMPTYELEMENT"].value
+        let firstPlantEmptyElement = firstPlant["EMPTYELEMENT"].value?.string
         XCTAssertNil(firstPlantEmptyElement, "Should be able to have nil value.")
     }
     
@@ -314,6 +314,17 @@ class AEXMLTests: XCTestCase {
         XCTAssertEqual(exampleDocument.root["ducks"]["duck"].last!.string, "Scrooge", "Should be able to iterate ducks now.")
     }
     
+    func testAddChildCDATA() {
+        let ducks = exampleDocument.root.addChild(name: "ducks")
+        ducks.addChild(name: "duck", cdataValue: "Donald")
+        ducks.addChild(name: "duck", cdataValue: "Daisy")
+        ducks.addChild(name: "duck", cdataValue: "Scrooge")
+        
+        let animalsCount = exampleDocument.root.children.count
+        XCTAssertEqual(animalsCount, 3, "Should be able to add child elements to an element.")
+        XCTAssertEqual(exampleDocument.root["ducks"]["duck"].last!.string, "Scrooge", "Should be able to iterate ducks now.")
+    }
+    
     func testAddChildWithAttributes() {
         let cats = exampleDocument.root["cats"]
         let dogs = exampleDocument.root["dogs"]
@@ -363,6 +374,12 @@ class AEXMLTests: XCTestCase {
         let string = "&<>'\""
         let escapedString = string.xmlEscaped
         XCTAssertEqual(escapedString, "&amp;&lt;&gt;&apos;&quot;")
+    }
+    
+    func testXMLEscapedCDATAString() {
+        let string = "&<>'\""
+        let escapedCDATAString = string.xmlEscapedCDATA
+        XCTAssertEqual(escapedCDATAString, "<![CDATA[&amp;&lt;&gt;&apos;&quot;]]>")
     }
     
     func testXMLString() {


### PR DESCRIPTION
What is Done
-----

- Added support for CDATA
This has been done being more backward compatible as possible.
The only code will break will be the access to AEXMLElement.value that has changed type from `string` to `AEXMLElementValue`.
It is a simple struct that wraps a plain string and will output a different escape sequence.