### PR TITLE
Fixed memory consumption issues parsing large XML files

### DIFF
--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -56,9 +56,8 @@ internal class AEXMLParser: NSObject, XMLParserDelegate {
     }
     
     func parser(_ parser: XMLParser, foundCharacters string: String) {
-        currentValue += string
-        let newValue = currentValue.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-        currentElement?.value = newValue == String() ? nil : newValue
+        currentValue.append(string.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines))
+        currentElement?.value = currentValue.isEmpty ? nil : currentValue
     }
     
     func parser(_ parser: XMLParser,


### PR DESCRIPTION
Fix for #117. 
Processing big XML files causes allocation of large amount of `String` objects, which consumes a lot of memory.