### PR TITLE
XMLParser and trim bug fix

### DIFF
--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -61,7 +61,7 @@ internal class AEXMLParser: NSObject, XMLParserDelegate {
     }
     
     func parser(_ parser: XMLParser, foundCharacters string: String) {
-        currentValue.append(trimWhitespace ? string.trimmingCharacters(in: .whitespacesAndNewlines) : string)
+        currentValue.append(string)
         currentElement?.value = currentValue.isEmpty ? nil : currentValue
     }
     
@@ -70,6 +70,9 @@ internal class AEXMLParser: NSObject, XMLParserDelegate {
                       namespaceURI: String?,
                       qualifiedName qName: String?)
     {
+        if trimWhitespace {
+            currentElement?.value = currentElement?.value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
         currentParent = currentParent?.parent
         currentElement = nil
     }

--- a/Tests/AEXMLTests/AEXMLTests.swift
+++ b/Tests/AEXMLTests/AEXMLTests.swift
@@ -349,6 +349,14 @@ class AEXMLTests: XCTestCase {
         XCTAssert(hasDescendant, "Should be able to determine that document has a child satisfying predicate.")
     }
     
+    func testSpecialCharacterTrimRead() {
+        let expected = "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<elements>\n\t<string name=\"this_and_that\">This &amp; that</string>\n</elements>"
+        
+        let readerDocument = try! AEXMLDocument(xml: expected)
+        let readerXml = readerDocument.xml
+        XCTAssertEqual(readerXml, expected, "Should be able to print XML formatted string.")
+    }
+    
     // MARK: - XML Write
     
     func testAddChild() {


### PR DESCRIPTION
Thank you for your library!

While using it I faced a problem. Reading a file with an element value with an escaped character, the value in the `AEXMLDocument` was removing the spaces around it. Setting the trimming to false, fixed the problem. But I wanted to have trimming :)

For example `This &amp; that` becomes `This&amp;that` and `This ôr that` becomes `Thisôr that`.

The problem is that `XMLParserDelegate` `parser(_:foundCharacters:)` might return multiple chunks of texts (https://developer.apple.com/documentation/foundation/xmlparserdelegate/1412539-parser ), which happens with special characters.

To fix it, I moved the trimming to the delegate method when the element ends.