### PR TITLE
Adding a way to get the XML string with spaces not tabs

### DIFF
--- a/Sources/Element.swift
+++ b/Sources/Element.swift
@@ -306,6 +306,11 @@ open class AEXMLElement {
         return xml.components(separatedBy: chars).joined(separator: "")
     }
     
+    /// Same as `xmlString` but with 4 spaces instead '\t' characters
+    open var xmlSpaces: String {
+        let chars = CharacterSet(charactersIn: "\t")
+        return xml.components(separatedBy: chars).joined(separator: "    ")
+    }
 }
 
 public extension String {

--- a/Tests/AEXMLTests/AEXMLTests.swift
+++ b/Tests/AEXMLTests/AEXMLTests.swift
@@ -435,6 +435,8 @@ class AEXMLTests: XCTestCase {
         XCTAssertEqual(testDocument.xml, "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<children>\n\t<child attribute=\"attributeValue&lt;&amp;&gt;\">value</child>\n\t<child />\n\t<child>&amp;&lt;&gt;&apos;&quot;</child>\n</children>", "Should be able to print XML formatted string.")
         
         XCTAssertEqual(testDocument.xmlCompact, "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?><children><child attribute=\"attributeValue&lt;&amp;&gt;\">value</child><child /><child>&amp;&lt;&gt;&apos;&quot;</child></children>", "Should be able to print compact XML string.")
+        
+        XCTAssertEqual(testDocument.xmlSpaces, "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<children>\n    <child attribute=\"attributeValue&lt;&amp;&gt;\">value</child>\n    <child />\n    <child>&amp;&lt;&gt;&apos;&quot;</child>\n</children>", "Should be able to print XML formatted string.")
     }
     
     // MARK: - XML Parse Performance


### PR DESCRIPTION
Some users, editor or IDEs will prefer getting the output with spaces instead of tabs.

This PR adds a computed variable, similar to `Element.xmlCompact`.