### PR TITLE
Add product to the Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,9 @@ import PackageDescription
 
 let package = Package(
     name: "AEXML",
+    products: [
+        .library(name: "AEXML", targets: ["AEXML"])
+    ],
     dependencies: [],
     targets: [
         .target(


### PR DESCRIPTION
When I use the latest version of AEXML with Swift 4.2 I get the following error:

```
'xcodeproj' /Users/pedropinera/src/github.com/tuist/xcodeproj: error: product dependency 'AEXML' not found
warning: dependency 'AEXML' is not used by any target
```

It seems that the SPM can't find it because it's not defined as a product in the package manifest.