### PR TITLE
Update for Swift 5

### DIFF
--- a/Sources/AEXML/Element.swift
+++ b/Sources/AEXML/Element.swift
@@ -321,7 +321,7 @@ open class AEXMLElement {
 public extension String {
     
     /// String representation of self with XML special characters escaped.
-    public var xmlEscaped: String {
+    var xmlEscaped: String {
         // we need to make sure "&" is escaped first. Not doing this may break escaping the other characters
         var escaped = replacingOccurrences(of: "&", with: "&amp;", options: .literal)
         


### PR DESCRIPTION
Removes warning: "'public' modifier is redundant for property declared in a public extension" in Swift 5