### PR TITLE
added an option to serialize xml by double space

### DIFF
--- a/AEXML.xcodeproj/project.pbxproj
+++ b/AEXML.xcodeproj/project.pbxproj
@@ -298,9 +298,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8B4A92801BDD47210011F36F /* Build configuration list for PBXNativeTarget "AEXML iOS" */;
 			buildPhases = (
+				8B4A92761BDD47210011F36F /* Headers */,
 				8B4A92741BDD47210011F36F /* Sources */,
 				8B4A92751BDD47210011F36F /* Frameworks */,
-				8B4A92761BDD47210011F36F /* Headers */,
 				8B4A92771BDD47210011F36F /* Resources */,
 			);
 			buildRules = (

--- a/Sources/AEXML/Element.swift
+++ b/Sources/AEXML/Element.swift
@@ -303,6 +303,12 @@ open class AEXMLElement {
         let chars = CharacterSet(charactersIn: "\t")
         return xml.components(separatedBy: chars).joined(separator: "    ")
     }
+    
+    /// Same as `xmlString` but with 2 spaces instead '\t' characters
+    open var xmlDoubleSpace: String {
+        let chars = CharacterSet(charactersIn: "\t")
+        return xml.components(separatedBy: chars).joined(separator: "  ")
+    }
 
     // MARK: - Helpers
 

--- a/Sources/AEXML/Element.swift
+++ b/Sources/AEXML/Element.swift
@@ -298,13 +298,13 @@ open class AEXMLElement {
         return xml.components(separatedBy: chars).joined(separator: "")
     }
     
-    /// Same as `xmlString` but with 4 spaces instead '\t' characters
+    /// Same as `xmlString` but with 4 spaces instead of '\t' character
     open var xmlSpaces: String {
         let chars = CharacterSet(charactersIn: "\t")
         return xml.components(separatedBy: chars).joined(separator: "    ")
     }
     
-    /// Same as `xmlString` but with 2 spaces instead '\t' characters
+    /// Same as `xmlString` but with 2 spaces instead of '\t' character
     open var xmlDoubleSpace: String {
         let chars = CharacterSet(charactersIn: "\t")
         return xml.components(separatedBy: chars).joined(separator: "  ")

--- a/Tests/AEXMLTests/AEXMLTests.swift
+++ b/Tests/AEXMLTests/AEXMLTests.swift
@@ -475,6 +475,8 @@ class AEXMLTests: XCTestCase {
         XCTAssertEqual(testDocument.xmlCompact, "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?><children><child attribute=\"attributeValue&lt;&amp;&gt;\">value</child><child /><child>&amp;&lt;&gt;&apos;&quot;&#10;</child></children>", "Should be able to print compact XML string.")
         
         XCTAssertEqual(testDocument.xmlSpaces, "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<children>\n    <child attribute=\"attributeValue&lt;&amp;&gt;\">value</child>\n    <child />\n    <child>&amp;&lt;&gt;&apos;&quot;&#10;</child>\n</children>", "Should be able to print XML formatted string.")
+        
+        XCTAssertEqual(testDocument.xmlDoubleSpace, "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<children>\n  <child attribute=\"attributeValue&lt;&amp;&gt;\">value</child>\n  <child />\n  <child>&amp;&lt;&gt;&apos;&quot;&#10;</child>\n</children>", "Should be able to print XML formatted string.")
     }
     
     // MARK: - XML Parse Performance


### PR DESCRIPTION
This is a simple addition where it allows the developer to serialize xml with Double Spaces (space_space) instead of the tab (\t) character.