### PR TITLE
Add DSL-like initializers for document and element

### DIFF
--- a/Sources/AEXML/Builders.swift
+++ b/Sources/AEXML/Builders.swift
@@ -1,0 +1,131 @@
+/**
+ *  https://github.com/tadija/AEXML
+ *  Copyright © Marko Tadić 2014-2024
+ *  Licensed under the MIT license
+ */
+
+// MARK: AEXMLDocumentBuilder
+
+@resultBuilder
+public enum AEXMLDocumentBuilder {
+
+    public static func buildBlock(_ component: AEXMLElement) -> AEXMLDocument {
+        AEXMLDocument(root: component)
+    }
+
+    public static func buildOptional(_ component: AEXMLElement?) -> AEXMLDocument {
+        AEXMLDocument(root: component)
+    }
+
+    public static func buildEither(first component: AEXMLElement) -> AEXMLDocument {
+        AEXMLDocument(root: component)
+    }
+
+    public static func buildEither(second component: AEXMLElement) -> AEXMLDocument {
+        AEXMLDocument(root: component)
+    }
+
+}
+
+// MARK: AEXMLDocument+AEXMLDocumentBuilder
+
+public extension AEXMLDocument {
+
+    /**
+     Convenience initializer - Creates and returns new XML Document object.
+
+     - parameter options: Options for XML Document header and parser settings (defaults to `AEXMLOptions()`).
+     - parameter rootBuilder: Builder for root XML element for XML Document.
+
+     - returns: Initialized XML Document object.
+     */
+    convenience init(options: AEXMLOptions = AEXMLOptions(),
+                     @AEXMLDocumentBuilder rootBuilder: () -> AEXMLElement) {
+        self.init(root: rootBuilder(),
+                  options: options)
+    }
+
+}
+
+// MARK: - AEXMLElementBuilder
+
+@resultBuilder
+public enum AEXMLElementBuilder {
+
+    public static func buildBlock(_ components: AEXMLElement...) -> [AEXMLElement] {
+        components
+    }
+
+    // MARK: If & switch support
+
+    public static func buildOptional(_ component: [AEXMLElement]?) -> [AEXMLElement] {
+        component ?? []
+    }
+
+    public static func buildEither(first component: [AEXMLElement]) -> [AEXMLElement] {
+        component
+    }
+
+    public static func buildEither(second component: [AEXMLElement]) -> [AEXMLElement] {
+        component
+    }
+
+    // MARK: For...in support
+
+    public static func buildArray(_ components: [[AEXMLElement]]) -> [AEXMLElement] {
+        components.flatMap { $0 }
+    }
+
+    // MARK: Limited availabiliy
+
+    public static func buildLimitedAvailability(_ component: [AEXMLElement]) -> [AEXMLElement] {
+        component
+    }
+
+    // MARK: Partial results
+
+    public static func buildExpression(_ expression: AEXMLElement) -> [AEXMLElement] {
+        [expression]
+    }
+
+    public static func buildExpression(_ expression: [AEXMLElement]) -> [AEXMLElement] {
+        expression
+    }
+
+    public static func buildExpression(_ expression: [[AEXMLElement]]) -> [AEXMLElement] {
+        expression.flatMap { $0 }
+    }
+
+    public static func buildPartialBlock(first: [AEXMLElement]) -> [AEXMLElement] {
+        first
+    }
+
+    public static func buildPartialBlock(accumulated: [AEXMLElement], next: [AEXMLElement]) -> [AEXMLElement] {
+        accumulated + next
+    }
+
+}
+
+// MARK: AEXMLElement+AEXMLElementBuilder
+
+public extension AEXMLElement {
+
+    /**
+     Convenience initializer - Creates a new XML element.
+
+     - parameter name: XML element name.
+     - parameter attributes: XML element attributes (defaults to empty dictionary).
+     - parameter childrenBuilder: Builder for the child XML elements.
+
+     - returns: An initialized `AEXMLElement` object.
+     */
+    convenience init(_ name: String,
+                     attributes: [String: String] = [:],
+                     @AEXMLElementBuilder childrenBuilder: () -> [AEXMLElement]) {
+        self.init(name: name,
+                  attributes: attributes)
+
+        addChildren(childrenBuilder())
+    }
+
+}


### PR DESCRIPTION
I recently looked at a bit of XML-handling code of mine and thought that the API could be improved to be more ergonomic using `@resultBuilder`s.

This introduces two `@resultBuilder`-based builders: `AEXMLDocumentBuilder` and `AEXMLElementBuilder`. The main difference is that the first produces an `AEXMLDocument` and only accepts a singular `AEXMLElement` as its root. The latter produces an array of `AEXMLElement`s.

Both can be used in conjunction to create new hierarchies of elements easily and quickly. Instead of creating child elements before adding them to their parents, they can be created in code in a way that more closely resembles the actual XML structure in the resulting document.

An example use from code that I plan to ship into production is the following. Note how the structure of the document is easily defined and resembles the XML string that would be generated from it.
I added the document builder to the function but I could as well have just wrapped the root element in a `AEXMLDocument {}` without it.

```swift
    @AEXMLDocumentBuilder
    private func buildSoapEnvelope(
        for action: String,
        in serviceType: String,
        with parameters: [String: String] = [:]
    ) -> AEXMLDocument {
        AEXMLElement("s:Envelope", attributes: [
            "xmlns:s": "http://schemas.xmlsoap.org/soap/envelope/",
            "s:encodingStyle": "http://schemas.xmlsoap.org/soap/encoding/"
        ]) {
            AEXMLElement("s:Body") {
                AEXMLElement("s:\(action)", attributes: [
                    "xmlns:u": serviceType
                ]) {

                    for parameter in parameters {
                        AEXMLElement(
                            name: parameter.key,
                            value: parameter.value
                        )
                    }

                }
            }
        }
    }
```

I think this API is very flexible and adds to the library's readability. It doesn't take away any existing APIs so they remain the same. Would love your feedback. Just let me know what you think about this addition and if I should adjust anything.

(Btw, I have been using your library for years and I am super happy with it! Thank you for providing this to the community!)