### PR TITLE
Throwing errors

### DIFF
--- a/Example/AEXMLDemo/ViewController.swift
+++ b/Example/AEXMLDemo/ViewController.swift
@@ -33,74 +33,134 @@ final class ViewController: UIViewController {
         options.parserSettings.shouldReportNamespacePrefixes = false
         options.parserSettings.shouldResolveExternalEntities = false
 
+        let xmlDoc: AEXMLDocument
+        let root: AEXMLElement
         do {
-            let xmlDoc = try AEXMLDocument(xml: data, options: options)
+            xmlDoc = try AEXMLDocument(xml: data, options: options)
+            root = try xmlDoc.root
+        } catch {
+            print("Failed to parse doc and root:", error)
+            return
+        }
 
-            // prints the same XML structure as original
-            print(xmlDoc.xml)
+        // prints the same XML structure as original
+        print(xmlDoc.xml)
 
-            // prints cats, dogs
-            for child in xmlDoc.root.children {
-                print(child.name)
-            }
+        // prints cats, dogs
+        for child in root.children {
+            print(child.name)
+        }
 
-            // prints Optional("Tinna") (first element)
-            print(String(describing: xmlDoc.root["cats"]["cat"].value))
+        // prints Optional("Tinna") (first element)
+        do {
+            let tinna = try root["cats"]["cat"].value
+            print(String(describing: tinna))
+        } catch {
+            print(error)
+        }
 
-            // prints Tinna (first element)
-            print(xmlDoc.root["cats"]["cat"].string)
+        // prints Tinna (first element)
+        do {
+            let tinna = try root["cats"]["cat"].string
+            print(tinna)
+        } catch {
+            print(error)
+        }
 
-            // prints Optional("Kika") (last element)
-            print(String(describing: xmlDoc.root["dogs"]["dog"].last?.value))
+        // prints Optional("Kika") (last element)
+        do {
+            let kika = try root["dogs"]["dog"].last?.value
+            print(String(describing: kika))
+        } catch {
+            print(error)
+        }
 
-            // prints Betty (3rd element)
-            print(xmlDoc.root["dogs"].children[2].string)
+        // prints Betty (3rd element)
+        do {
+            let betty = try root["dogs"].children[2].string
+            print(betty)
+        } catch {
+            print(error)
+        }
 
-            // prints Tinna, Rose, Caesar
-            if let cats = xmlDoc.root["cats"]["cat"].all {
-                for cat in cats {
+        // prints Tinna, Rose, Caesar
+        do {
+            let cats = try root["cats"]["cat"]
+            if let allCats = cats.all {
+                for cat in allCats {
                     if let name = cat.value {
                         print(name)
                     }
                 }
             }
+        } catch {
+            print(error)
+        }
 
-            // prints Villy, Spot
-            for dog in xmlDoc.root["dogs"]["dog"].all! {
+        // prints Villy, Spot
+        do {
+            let dogs = try root["dogs"]["dog"]
+            for dog in dogs.all! {
                 if let color = dog.attributes["color"] {
                     if color == "white" {
                         print(dog.string)
                     }
                 }
             }
-
-            // prints Tinna
-            if let cats = xmlDoc.root["cats"]["cat"].all(withValue: "Tinna") {
-                for cat in cats {
-                    print(cat.string)
-                }
-            }
-
-            // prints Caesar
-            if let cats = xmlDoc.root["cats"]["cat"].all(withAttributes: ["breed" : "Domestic", "color" : "yellow"]) {
-                for cat in cats {
-                    print(cat.string)
-                }
-            }
-
-            // prints 4
-            print(xmlDoc.root["cats"]["cat"].count)
-
-            // prints Siberian
-            print(xmlDoc.root["cats"]["cat"].attributes["breed"]!)
-
-            // prints <cat breed="Siberian" color="lightgray">Tinna</cat>
-            print(xmlDoc.root["cats"]["cat"].xmlCompact)
-
-            // prints Optional(AEXML.AEXMLError.elementNotFound)
-            print(String(describing: xmlDoc["NotExistingElement"].error))
         } catch {
-            print("\(error)")
+            print(error)
+        }
+
+        // prints Tinna
+        do {
+            let cats = try root["cats"]["cat"]
+            if let tinna = cats.all(withValue: "Tinna") {
+                for cat in tinna {
+                    print(cat.string)
+                }
+            }
+        } catch {
+            print(error)
+        }
+
+        // prints Caesar
+        do {
+            let cats = try root["cats"]["cat"]
+            if let caesar = cats.all(withAttributes: ["breed" : "Domestic", "color" : "yellow"]) {
+                for cat in caesar {
+                    print(cat.string)
+                }
+            }
+        } catch {
+            print(error)
+        }
+
+        // prints 4
+        do {
+            print(try root["cats"]["cat"].count)
+        } catch {
+            print(error)
+        }
+
+        // prints Siberian
+        do {
+            print(try root["cats"]["cat"].attributes["breed"]!)
+        } catch {
+            print(error)
+        }
+
+        // prints <cat breed="Siberian" color="lightgray">Tinna</cat>
+        do {
+            print(try root["cats"]["cat"].xmlCompact)
+        } catch {
+            print(error)
+        }
+
+        // prints Optional(AEXML.AEXMLError.elementNotFound)
+        do {
+            let _ = try xmlDoc["NotExistingElement"]
+        } catch {
+            print(error)
         }
     }
     
@@ -121,8 +181,8 @@ final class ViewController: UIViewController {
             let document = try AEXMLDocument(xml: data)
             var parsedText = String()
             // parse known structure
-            for plant in document["CATALOG"]["PLANT"].all! {
-                parsedText += plant["COMMON"].string + "\n"
+            for plant in try document["CATALOG"]["PLANT"].all! {
+                parsedText += try plant["COMMON"].string + "\n"
             }
             textView.text = parsedText
         } catch {
@@ -167,7 +227,7 @@ final class ViewController: UIViewController {
             let document = try AEXMLDocument(xml: data)
             var parsedText = String()
             // parse unknown structure
-            for child in document.root.children {
+            for child in try document.root.children {
                 parsedText += child.xml + "\n"
             }
             textView.text = parsedText

--- a/README.md
+++ b/README.md
@@ -63,75 +63,136 @@ guard let
     let data = try? Data(contentsOf: URL(fileURLWithPath: xmlPath))
 else { return }
 
+let xmlDoc = try AEXMLDocument(xml: data, options: options)
+
+let xmlDoc: AEXMLDocument
+let root: AEXMLElement
 do {
-    let xmlDoc = try AEXMLDocument(xml: data, options: options)
-        
-    // prints the same XML structure as original
-    print(xmlDoc.xml)
-    
-    // prints cats, dogs
-    for child in xmlDoc.root.children {
-        print(child.name)
-    }
-    
-    // prints Optional("Tinna") (first element)
-    print(xmlDoc.root["cats"]["cat"].value)
-    
-    // prints Tinna (first element)
-    print(xmlDoc.root["cats"]["cat"].string)
-    
-    // prints Optional("Kika") (last element)
-    print(xmlDoc.root["dogs"]["dog"].last?.value)
-    
-    // prints Betty (3rd element)
-    print(xmlDoc.root["dogs"].children[2].string)
-    
-    // prints Tinna, Rose, Caesar
-    if let cats = xmlDoc.root["cats"]["cat"].all {
-        for cat in cats {
+    xmlDoc = try AEXMLDocument(xml: data, options: options)
+    root = try xmlDoc.root
+} catch {
+    print("Failed to parse doc and root:", error)
+    return
+}
+
+// prints the same XML structure as original
+print(xmlDoc.xml)
+
+// prints cats, dogs
+for child in root.children {
+    print(child.name)
+}
+
+// prints Optional("Tinna") (first element)
+do {
+    let tinna = try root["cats"]["cat"].value
+    print(String(describing: tinna))
+} catch {
+    print(error)
+}
+
+// prints Tinna (first element)
+do {
+    let tinna = try root["cats"]["cat"].string
+    print(tinna)
+} catch {
+    print(error)
+}
+
+// prints Optional("Kika") (last element)
+do {
+    let kika = try root["dogs"]["dog"].last?.value
+    print(String(describing: kika))
+} catch {
+    print(error)
+}
+
+// prints Betty (3rd element)
+do {
+    let betty = try root["dogs"].children[2].string
+    print(betty)
+} catch {
+    print(error)
+}
+
+// prints Tinna, Rose, Caesar
+do {
+    let cats = try root["cats"]["cat"]
+    if let allCats = cats.all {
+        for cat in allCats {
             if let name = cat.value {
                 print(name)
             }
         }
     }
-    
-    // prints Villy, Spot
-    for dog in xmlDoc.root["dogs"]["dog"].all! {
+} catch {
+    print(error)
+}
+
+// prints Villy, Spot
+do {
+    let dogs = try root["dogs"]["dog"]
+    for dog in dogs.all! {
         if let color = dog.attributes["color"] {
             if color == "white" {
                 print(dog.string)
             }
         }
     }
-    
-    // prints Tinna
-    if let cats = xmlDoc.root["cats"]["cat"].all(withValue: "Tinna") {
-        for cat in cats {
-            print(cat.string)
-        }
-    }
-    
-    // prints Caesar
-    if let cats = xmlDoc.root["cats"]["cat"].all(withAttributes: ["breed" : "Domestic", "color" : "yellow"]) {
-        for cat in cats {
-            print(cat.string)
-        }
-    }
-    
-    // prints 4
-    print(xmlDoc.root["cats"]["cat"].count)
-    
-    // prints Siberian
-    print(xmlDoc.root["cats"]["cat"].attributes["breed"]!)
-    
-    // prints <cat breed="Siberian" color="lightgray">Tinna</cat>
-    print(xmlDoc.root["cats"]["cat"].xmlCompact)
-    
-    // prints Optional(AEXML.AEXMLError.elementNotFound)
-    print(xmlDoc["NotExistingElement"].error)
+} catch {
+    print(error)
 }
-catch {
-    print("\(error)")
+
+// prints Tinna
+do {
+    let cats = try root["cats"]["cat"]
+    if let tinna = cats.all(withValue: "Tinna") {
+        for cat in tinna {
+            print(cat.string)
+        }
+    }
+} catch {
+    print(error)
+}
+
+// prints Caesar
+do {
+    let cats = try root["cats"]["cat"]
+    if let caesar = cats.all(withAttributes: ["breed" : "Domestic", "color" : "yellow"]) {
+        for cat in caesar {
+            print(cat.string)
+        }
+    }
+} catch {
+    print(error)
+}
+
+// prints 4
+do {
+    print(try root["cats"]["cat"].count)
+} catch {
+    print(error)
+}
+
+// prints Siberian
+do {
+    print(try root["cats"]["cat"].attributes["breed"]!)
+} catch {
+    print(error)
+}
+
+// prints <cat breed="Siberian" color="lightgray">Tinna</cat>
+do {
+    print(try root["cats"]["cat"].xmlCompact)
+} catch {
+    print(error)
+}
+
+// prints Optional(AEXML.AEXMLError.elementNotFound)
+do {
+    let _ = try xmlDoc["NotExistingElement"]
+} catch {
+    print(error)
 }
 ```
 

--- a/Sources/AEXML/Document.swift
+++ b/Sources/AEXML/Document.swift
@@ -18,14 +18,16 @@ open class AEXMLDocument: AEXMLElement {
     
     // MARK: - Properties
     
-    /// Root (the first child element) element of XML Document **(Empty element with error if not exists)**.
+    /// Root (the first child element) element of XML Document.
+    ///
+    /// - Throws: `AEXMLError.rootElementMissing` if not exists.
     open var root: AEXMLElement {
-        guard let rootElement = children.first else {
-            let errorElement = AEXMLElement(name: "Error")
-            errorElement.error = AEXMLError.rootElementMissing
-            return errorElement
+        get throws {
+            guard let rootElement = children.first else {
+                throw AEXMLError.rootElementMissing
+            }
+            return rootElement
         }
-        return rootElement
     }
     
     public let options: AEXMLOptions
@@ -103,7 +105,9 @@ open class AEXMLDocument: AEXMLElement {
     /// Override of `xml` property of `AEXMLElement` - it just inserts XML Document header at the beginning.
     open override var xml: String {
         var xml =  "\(options.documentHeader.xmlString)\n"
-        xml += root.xml
+        if let root = try? root {
+            xml += root.xml
+        }
         return xml
     }
     

--- a/Sources/AEXML/Element.swift
+++ b/Sources/AEXML/Element.swift
@@ -82,7 +82,7 @@ open class AEXMLElement {
             guard let
                     first = children.first(where: { $0.name == key })
             else {
-                throw AEXMLError.elementNotFound
+                throw AEXMLError.elementNotFound(key)
             }
             return first
         }

--- a/Sources/AEXML/Element.swift
+++ b/Sources/AEXML/Element.swift
@@ -34,9 +34,6 @@ open class AEXMLElement {
     /// XML Element attributes.
     open var attributes: [String : String]
     
-    /// Error value (`nil` if there is no error).
-    open var error: AEXMLError?
-    
     /// String representation of `value` property (if `value` is `nil` this is empty String).
     open var string: String { return value ?? String() }
     
@@ -77,16 +74,18 @@ open class AEXMLElement {
     
     // MARK: - XML Read
     
-    /// The first element with given name **(Empty element with error if not exists)**.
+    /// The first element with given name.
+    ///
+    /// - Throws: `AEXMLError.elementNotFound` if not exists.
     open subscript(key: String) -> AEXMLElement {
-        guard let
-            first = children.first(where: { $0.name == key })
-        else {
-            let errorElement = AEXMLElement(name: key)
-            errorElement.error = AEXMLError.elementNotFound
-            return errorElement
+        get throws {
+            guard let
+                    first = children.first(where: { $0.name == key })
+            else {
+                throw AEXMLError.elementNotFound
+            }
+            return first
         }
-        return first
     }
     
     /// Returns all of the elements with equal name as `self` **(nil if not exists)**.

--- a/Sources/AEXML/Error.swift
+++ b/Sources/AEXML/Error.swift
@@ -10,10 +10,10 @@ import FoundationXML
 #endif
 
 /// A type representing error value that can be thrown or inside `error` property of `AEXMLElement`.
-public enum AEXMLError: Error {
+public enum AEXMLError: Error, Equatable {
     /// This will be inside `error` property of `AEXMLElement` when subscript is used for not-existing element.
-    case elementNotFound
-    
+    case elementNotFound(String)
+
     /// This will be inside `error` property of `AEXMLDocument` when there is no root element.
     case rootElementMissing
     

--- a/Tests/AEXMLTests/AEXMLTests.swift
+++ b/Tests/AEXMLTests/AEXMLTests.swift
@@ -9,16 +9,16 @@ import Foundation
 import FoundationXML
 #endif
 
-import XCTest
+import Testing
 @testable import AEXML
 
-class AEXMLTests: XCTestCase {
-    
+class AEXMLTests {
+
     // MARK: - Properties
     
     var exampleDocument = AEXMLDocument()
     var plantsDocument = AEXMLDocument()
-    
+
     // MARK: - Helpers
     
     func URLForResource(fileName: String, withExtension ext: String) -> URL {
@@ -34,435 +34,427 @@ class AEXMLTests: XCTestCase {
         }
     }
     
-    func xmlDocumentFromURL(url: URL) -> AEXMLDocument {
+    func xmlDocumentFromURL(url: URL) throws -> AEXMLDocument {
         var xmlDocument = AEXMLDocument()
         
-        do {
-            let data = try Data.init(contentsOf: url)
-            xmlDocument = try AEXMLDocument(xml: data)
-        } catch {
-            print(error)
-        }
-        
+        let data = try Data.init(contentsOf: url)
+        xmlDocument = try AEXMLDocument(xml: data)
+
         return xmlDocument
     }
     
-    func readXMLFromFile(filename: String) -> AEXMLDocument {
+    func readXMLFromFile(filename: String) throws -> AEXMLDocument {
         let url = URLForResource(fileName: filename, withExtension: "xml")
-        return xmlDocumentFromURL(url: url)
+        return try xmlDocumentFromURL(url: url)
     }
     
     // MARK: - Setup & Teardown
-    
-    override func setUp() {
-        super.setUp()
-        
+
+    init() throws {
         // create some sample xml documents
-        exampleDocument = readXMLFromFile(filename: "example")
-        plantsDocument = readXMLFromFile(filename: "plant_catalog")
+        exampleDocument = try readXMLFromFile(filename: "example")
+        plantsDocument = try readXMLFromFile(filename: "plant_catalog")
     }
-    
-    override func tearDown() {
-        // reset sample xml document
-        exampleDocument = AEXMLDocument()
-        plantsDocument = AEXMLDocument()
-        
-        super.tearDown()
-    }
-    
+
     // MARK: - XML Document
-    
-    func testXMLDocumentManualDataLoading() {
-        do {
-            let url = URLForResource(fileName: "example", withExtension: "xml")
-            let data = try Data.init(contentsOf: url)
-            
-            let testDocument = AEXMLDocument()
-            try testDocument.loadXML(data)
-            XCTAssertEqual(testDocument.root.name, "animals", "Should be able to find root element.")
-        } catch {
-            XCTFail("Should be able to load XML Document with given Data.")
-        }
+
+    @Test
+    func testXMLDocumentManualDataLoading() throws {
+        let url = URLForResource(fileName: "example", withExtension: "xml")
+        let data = try Data.init(contentsOf: url)
+
+        let testDocument = AEXMLDocument()
+        try testDocument.loadXML(data)
+
+        let root = try testDocument.root
+        #expect(root.name == "animals")
+    }
+
+    @Test
+    func testXMLDocumentInitFromString() throws {
+        let testDocument = try AEXMLDocument(xml: exampleDocument.xml)
+        #expect(testDocument.xml == exampleDocument.xml)
+    }
+
+    @Test
+    func testXMLOptions() throws {
+        var options = AEXMLOptions()
+        options.documentHeader.version = 2.0
+        options.documentHeader.encoding = "utf-16"
+        options.documentHeader.standalone = "yes"
+
+        let testDocument = try AEXMLDocument(xml: "<foo><bar>hello</bar></foo>", options: options)
+        #expect(testDocument.xml == "<?xml version=\"2.0\" encoding=\"utf-16\" standalone=\"yes\"?>\n<foo>\n\t<bar>hello</bar>\n</foo>")
+
+        let firstString = try testDocument.root["bar"].first?.string
+        #expect(firstString == "hello")
+    }
+
+    @Test
+    func testXMLParser() throws {
+        let testDocument = AEXMLDocument()
+        let url = URLForResource(fileName: "example", withExtension: "xml")
+        let data = try Data.init(contentsOf: url)
+
+        let parser = AEXMLParser(document: testDocument, data: data)
+        try parser.parse()
+
+        let rootName = try testDocument.root.name
+        #expect(rootName == "animals")
+    }
+
+    @Test
+    func testXMLParserTrimsWhitespace() throws {
+        let result = try whitespaceResult(shouldTrimWhitespace: true)
+        #expect(result == "Hello,")
+    }
+
+    @Test
+    func testXMLParserWithoutTrimmingWhitespace() throws {
+        let result = try whitespaceResult(shouldTrimWhitespace: false)
+        #expect(result == "Hello, ")
     }
     
-    func testXMLDocumentInitFromString() {
-        do {
-            let testDocument = try AEXMLDocument(xml: exampleDocument.xml)
-            XCTAssertEqual(testDocument.xml, exampleDocument.xml)
-        } catch {
-            XCTFail("Should be able to initialize XML Document from XML String.")
-        }
+    private func whitespaceResult(shouldTrimWhitespace: Bool) throws -> String? {
+        var options = AEXMLOptions()
+        options.parserSettings.shouldTrimWhitespace = shouldTrimWhitespace
+
+        let testDocument = AEXMLDocument(options: options)
+        let url = URLForResource(fileName: "whitespace_examples", withExtension: "xml")
+        let data = try Data.init(contentsOf: url)
+
+        let parser = AEXMLParser(document: testDocument, data: data)
+        try parser.parse()
+
+        return try testDocument.root["text"].first?.string
     }
-    
-    func testXMLOptions() {
-        do {
-            var options = AEXMLOptions()
-            options.documentHeader.version = 2.0
-            options.documentHeader.encoding = "utf-16"
-            options.documentHeader.standalone = "yes"
-            
-            let testDocument = try AEXMLDocument(xml: "<foo><bar>hello</bar></foo>", options: options)
-            XCTAssertEqual(testDocument.xml, "<?xml version=\"2.0\" encoding=\"utf-16\" standalone=\"yes\"?>\n<foo>\n\t<bar>hello</bar>\n</foo>")
-            XCTAssertEqual(testDocument.root["bar"].first?.string, "hello")
-        } catch {
-            XCTFail("Should be able to initialize XML Document with custom AEXMLOptions.")
-        }
-    }
-    
-    func testXMLParser() {
-        do {
-            let testDocument = AEXMLDocument()
-            let url = URLForResource(fileName: "example", withExtension: "xml")
-            let data = try Data.init(contentsOf: url)
-            
-            let parser = AEXMLParser(document: testDocument, data: data)
-            try parser.parse()
-            
-            XCTAssertEqual(testDocument.root.name, "animals", "Should be able to find root element.")
-        } catch {
-            XCTFail("Should be able to parse XML Data into XML Document without throwing error.")
-        }
-    }
-    
-    func testXMLParserTrimsWhitespace() {
-        let result = whitespaceResult(shouldTrimWhitespace: true)
-        XCTAssertEqual(result, "Hello,")
-    }
-    
-    func testXMLParserWithoutTrimmingWhitespace(){
-        let result = whitespaceResult(shouldTrimWhitespace: false)
-        XCTAssertEqual(result, "Hello, ")
-    }
-    
-    private func whitespaceResult(shouldTrimWhitespace: Bool) -> String?{
-        do {
-            var options = AEXMLOptions()
-            options.parserSettings.shouldTrimWhitespace = shouldTrimWhitespace
-            
-            let testDocument = AEXMLDocument(options: options)
-            let url = URLForResource(fileName: "whitespace_examples", withExtension: "xml")
-            let data = try Data.init(contentsOf: url)
-            
-            let parser = AEXMLParser(document: testDocument, data: data)
-            try parser.parse()
-            
-            return testDocument.root["text"].first?.string
-        } catch {
-            XCTFail("Should be able to parse XML without throwing an error")
-        }
-        return nil
-    }
-    
+
+    @Test
     func testXMLParserError() {
-        do {
-            let testDocument = AEXMLDocument()
-            let testData = Data()
-            let parser = AEXMLParser(document: testDocument, data: testData)
+        let testDocument = AEXMLDocument()
+        let testData = Data()
+        let parser = AEXMLParser(document: testDocument, data: testData)
+        #expect(throws: AEXMLError.parsingFailed) {
             try parser.parse()
-        } catch {
-            XCTAssertEqual(error.localizedDescription, AEXMLError.parsingFailed.localizedDescription)
         }
     }
     
     // MARK: - XML Read
-    
-    func testRootElement() {
-        XCTAssertEqual(exampleDocument.root.name, "animals", "Should be able to find root element.")
-        
+
+    @Test
+    func testRootElement() throws {
+        let root = try exampleDocument.root
+        #expect(root.name == "animals")
+
         let documentWithoutRootElement = AEXMLDocument()
-        let rootElement = documentWithoutRootElement.root
-        XCTAssertEqual(rootElement.error, AEXMLError.rootElementMissing, "Should have RootElementMissing error.")
+        #expect(throws: AEXMLError.rootElementMissing) {
+            try documentWithoutRootElement.root
+        }
     }
-    
-    func testParentElement() {
-        XCTAssertEqual(exampleDocument.root["cats"].parent!.name, "animals", "Should be able to find parent element.")
+
+    @Test
+    func testParentElement() throws {
+        let root = try exampleDocument.root
+        let cats = try root["cats"]
+        let parent = try #require(cats.parent)
+        #expect(parent.name == "animals")
     }
-    
-    func testChildrenElements() {
+
+    @Test
+    func testChildrenElements() throws {
+        let cats = try exampleDocument.root["cats"]
         var count = 0
-        for _ in exampleDocument.root["cats"].children {
+        for _ in cats.children {
             count += 1
         }
-        XCTAssertEqual(count, 4, "Should be able to iterate children elements")
+        #expect(count == 4, "Should be able to iterate children elements")
     }
-    
-    func testName() {
-        let secondChildElementName = exampleDocument.root.children[1].name
-        XCTAssertEqual(secondChildElementName, "dogs", "Should be able to return element name.")
+
+    @Test
+    func testName() throws {
+        let secondChildElementName = try exampleDocument.root.children[1].name
+        #expect(secondChildElementName == "dogs", "Should be able to return element name.")
     }
-    
-    func testAttributes() {
-        let firstCatAttributes = exampleDocument.root["cats"]["cat"].attributes
-        
+
+    @Test
+    func testAttributes() throws {
+        let firstCatAttributes = try exampleDocument.root["cats"]["cat"].attributes
+
         // iterate attributes
         var count = 0
         for _ in firstCatAttributes {
             count += 1
         }
-        XCTAssertEqual(count, 2, "Should be able to iterate element attributes.")
-        
+        #expect(count == 2, "Should be able to iterate element attributes.")
+
         // get attribute value
-        if let firstCatBreed = firstCatAttributes["breed"] {
-            XCTAssertEqual(firstCatBreed, "Siberian", "Should be able to return attribute value.")
-        } else {
-            XCTFail("The first cat should have breed attribute.")
-        }
+        let firstCatBreed = firstCatAttributes["breed"]
+        #expect(firstCatBreed == "Siberian", "Should be able to return attribute value.")
     }
-    
-    func testValue() {
-        let firstPlant = plantsDocument.root["PLANT"]
-        
-        let firstPlantCommon = firstPlant["COMMON"].value!
-        XCTAssertEqual(firstPlantCommon, "Bloodroot", "Should be able to return element value as optional string.")
-        
-        let firstPlantElementWithoutValue = firstPlant["ELEMENTWITHOUTVALUE"].value
-        XCTAssertNil(firstPlantElementWithoutValue, "Should be able to have nil value.")
-        
-        let firstPlantEmptyElement = firstPlant["EMPTYELEMENT"].value
-        XCTAssertNil(firstPlantEmptyElement, "Should be able to have nil value.")
-    }
-    
-    func testStringValue() {
-        let firstPlant = plantsDocument.root["PLANT"]
-        
-        let firstPlantCommon = firstPlant["COMMON"].string
-        XCTAssertEqual(firstPlantCommon, "Bloodroot", "Should be able to return element value as string.")
-        
-        let firstPlantElementWithoutValue = firstPlant["ELEMENTWITHOUTVALUE"].string
-        XCTAssertEqual(firstPlantElementWithoutValue, "", "Should be able to return empty string if element has no value.")
-        
-        let firstPlantEmptyElement = firstPlant["EMPTYELEMENT"].string
-        XCTAssertEqual(firstPlantEmptyElement, String(), "Should be able to return empty string if element has no value.")
-    }
-    
-    func testBoolValue() {
-        let firstTrueString = plantsDocument.root["PLANT"]["TRUESTRING"].bool
-        XCTAssertEqual(firstTrueString, true, "Should be able to cast element value as Bool.")
-        
-        let firstFalseString = plantsDocument.root["PLANT"]["FALSESTRING"].bool
-        XCTAssertEqual(firstFalseString, false, "Should be able to cast element value as Bool.")
 
-        let firstTrueString2 = plantsDocument.root["PLANT"]["TRUESTRING2"].bool
-        XCTAssertEqual(firstTrueString2, true, "Should be able to cast element value as Bool.")
+    @Test
+    func testValue() throws {
+        let firstPlant = try plantsDocument.root["PLANT"]
 
-        let firstFalseString2 = plantsDocument.root["PLANT"]["FALSESTRING2"].bool
-        XCTAssertEqual(firstFalseString2, false, "Should be able to cast element value as Bool.")
-        
-        let firstTrueInt = plantsDocument.root["PLANT"]["TRUEINT"].bool
-        XCTAssertEqual(firstTrueInt, true, "Should be able to cast element value as Bool.")
-        
-        let firstFalseInt = plantsDocument.root["PLANT"]["FALSEINT"].bool
-        XCTAssertEqual(firstFalseInt, false, "Should be able to cast element value as Bool.")
-        
-        let firstElementWithoutValue = plantsDocument.root["ELEMENTWITHOUTVALUE"].bool
-        XCTAssertNil(firstElementWithoutValue, "Should be able to return nil if value can't be represented as Bool.")
+        let firstPlantCommon = try firstPlant["COMMON"].value
+        #expect(firstPlantCommon == "Bloodroot", "Should be able to return element value as optional string.")
+
+        let firstPlantElementWithoutValue = try firstPlant["ELEMENTWITHOUTVALUE"].value
+        #expect(firstPlantElementWithoutValue == nil, "Should be able to have nil value.")
+
+        let firstPlantEmptyElement = try firstPlant["EMPTYELEMENT"].value
+        #expect(firstPlantEmptyElement == nil, "Should be able to have nil value.")
     }
-    
-    func testIntValue() {
-        let firstPlantZone = plantsDocument.root["PLANT"]["ZONE"].int
-        XCTAssertEqual(firstPlantZone, 4, "Should be able to cast element value as Integer.")
-        
-        let firstPlantPrice = plantsDocument.root["PLANT"]["PRICE"].int
-        XCTAssertNil(firstPlantPrice, "Should be able to return nil if value can't be represented as Integer.")
+
+    @Test
+    func testStringValue() throws {
+        let firstPlant = try plantsDocument.root["PLANT"]
+
+        let firstPlantCommon = try firstPlant["COMMON"].string
+        #expect(firstPlantCommon == "Bloodroot", "Should be able to return element value as string.")
+
+        let firstPlantElementWithoutValue = try firstPlant["ELEMENTWITHOUTVALUE"].string
+        #expect(firstPlantElementWithoutValue == "", "Should be able to return empty string if element has no value.")
+
+        let firstPlantEmptyElement = try firstPlant["EMPTYELEMENT"].string
+        #expect(firstPlantEmptyElement == String(), "Should be able to return empty string if element has no value.")
     }
-    
-    func testDoubleValue() {
-        let firstPlantPrice = plantsDocument.root["PLANT"]["PRICE"].double
-        XCTAssertEqual(firstPlantPrice, 2.44, "Should be able to cast element value as Double.")
-        
-        let firstPlantBotanical = plantsDocument.root["PLANT"]["BOTANICAL"].double
-        XCTAssertNil(firstPlantBotanical, "Should be able to return nil if value can't be represented as Double.")
+
+    @Test
+    func testBoolValue() throws {
+        let root = try plantsDocument.root
+
+        let firstTrueString = try root["PLANT"]["TRUESTRING"].bool
+        #expect(firstTrueString == true, "Should be able to cast element value as Bool.")
+
+        let firstFalseString = try root["PLANT"]["FALSESTRING"].bool
+        #expect(firstFalseString == false, "Should be able to cast element value as Bool.")
+
+        let firstTrueString2 = try root["PLANT"]["TRUESTRING2"].bool
+        #expect(firstTrueString2 == true, "Should be able to cast element value as Bool.")
+
+        let firstFalseString2 = try root["PLANT"]["FALSESTRING2"].bool
+        #expect(firstFalseString2 == false, "Should be able to cast element value as Bool.")
+
+        let firstTrueInt = try root["PLANT"]["TRUEINT"].bool
+        #expect(firstTrueInt == true, "Should be able to cast element value as Bool.")
+
+        let firstFalseInt = try root["PLANT"]["FALSEINT"].bool
+        #expect(firstFalseInt == false, "Should be able to cast element value as Bool.")
+
+        let firstElementWithoutValue = try root["PLANT"]["ELEMENTWITHOUTVALUE"].bool
+        #expect(firstElementWithoutValue == nil, "Should be able to return nil if value can't be represented as Bool.")
     }
-    
+
+    @Test
+    func testIntValue() throws {
+        let firstPlantZone = try plantsDocument.root["PLANT"]["ZONE"].int
+        #expect(firstPlantZone == 4, "Should be able to cast element value as Integer.")
+
+        let firstPlantPrice = try plantsDocument.root["PLANT"]["PRICE"].int
+        #expect(firstPlantPrice == nil, "Should be able to return nil if value can't be represented as Integer.")
+    }
+
+    @Test
+    func testDoubleValue() throws {
+        let firstPlantPrice = try plantsDocument.root["PLANT"]["PRICE"].double
+        #expect(firstPlantPrice == 2.44, "Should be able to cast element value as Double.")
+
+        let firstPlantBotanical = try plantsDocument.root["PLANT"]["BOTANICAL"].double
+        #expect(firstPlantBotanical == nil, "Should be able to return nil if value can't be represented as Double.")
+    }
+
+    @Test
     func testNotExistingElement() {
         // non-optional
-        XCTAssertNotNil(exampleDocument.root["ducks"]["duck"].error, "Should contain error inside element which does not exist.")
-        XCTAssertEqual(exampleDocument.root["ducks"]["duck"].error, AEXMLError.elementNotFound, "Should have ElementNotFound error.")
-        XCTAssertEqual(exampleDocument.root["ducks"]["duck"].string, String(), "Should have empty value.")
-        
+        #expect(throws: AEXMLError.elementNotFound) {
+            try exampleDocument.root["ducks"]["duck"]
+        }
+
         // optional
-        if let _ = exampleDocument.root["ducks"]["duck"].first {
-            XCTFail("Should not be able to find ducks here.")
-        } else {
-            XCTAssert(true)
-        }
+        let optional = try? exampleDocument.root["ducks"]["duck"].first
+        #expect(optional == nil)
     }
-    
-    func testAllElements() {
+
+    @Test
+    func testAllElements() throws {
         var count = 0
-        if let cats = exampleDocument.root["cats"]["cat"].all {
-            for cat in cats {
-                XCTAssertNotNil(cat.parent, "Each child element should have its parent element.")
-                count += 1
-            }
+        let cats = try exampleDocument.root["cats"]["cat"]
+        let allCats = try #require(cats.all)
+        for cat in allCats {
+            #expect(cat.parent != nil, "Each child element should have its parent element.")
+            count += 1
         }
-        XCTAssertEqual(count, 4, "Should be able to iterate all elements")
+        #expect(count == 4, "Should be able to iterate all elements")
     }
-    
-    func testFirstElement() {
-        let catElement = exampleDocument.root["cats"]["cat"]
+
+    @Test
+    func testFirstElement() throws {
+        let catElement = try exampleDocument.root["cats"]["cat"]
         let firstCatExpectedValue = "Tinna"
         
         // non-optional
-        XCTAssertEqual(catElement.string, firstCatExpectedValue, "Should be able to find the first element as non-optional.")
-        
+        #expect(catElement.string == firstCatExpectedValue, "Should be able to find the first element as non-optional.")
+
         // optional
-        if let cat = catElement.first {
-            XCTAssertEqual(cat.string, firstCatExpectedValue, "Should be able to find the first element as optional.")
-        } else {
-            XCTFail("Should be able to find the first element.")
-        }
+        let cat = try #require(catElement.first)
+        #expect(cat.string == firstCatExpectedValue, "Should be able to find the first element as optional.")
     }
-    
-    func testLastElement() {
-        if let dog = exampleDocument.root["dogs"]["dog"].last {
-            XCTAssertEqual(dog.string, "Kika", "Should be able to find the last element.")
-        } else {
-            XCTFail("Should be able to find the last element.")
-        }
+
+    @Test
+    func testLastElement() throws {
+        let dogs = try exampleDocument.root["dogs"]["dog"]
+        #expect(dogs.last?.string == "Kika", "Should be able to find the last element.")
     }
-    
-    func testCountElements() {
-        let dogsCount = exampleDocument.root["dogs"]["dog"].count
-        XCTAssertEqual(dogsCount, 4, "Should be able to count elements.")
+
+    @Test
+    func testCountElements() throws {
+        let dogsCount = try exampleDocument.root["dogs"]["dog"].count
+        #expect(dogsCount == 4, "Should be able to count elements.")
     }
-    
-    func testAllWithValue() {
-        let cats = exampleDocument.root["cats"]
+
+    @Test
+    func testAllWithValue() throws {
+        let cats = try exampleDocument.root["cats"]
         cats.addChild(name: "cat", value: "Tinna")
-        
-        var count = 0
-        if let tinnas = cats["cat"].all(withValue: "Tinna") {
-            for _ in tinnas {
-                count += 1
-            }
-        }
-        XCTAssertEqual(count, 2, "Should be able to return elements with given value.")
+
+        let catsElement = try cats["cat"]
+        let tinnas = try #require(catsElement.all(withValue: "Tinna"))
+        #expect(tinnas.count == 2, "Should be able to return elements with given value.")
     }
-    
-    func testAllWithAttributes() {
-        var count = 0
-        if let bulls = exampleDocument.root["dogs"]["dog"].all(withAttributes: ["color" : "white"]) {
-            for _ in bulls {
-                count += 1
-            }
-        }
-        XCTAssertEqual(count, 2, "Should be able to return elements with given attributes.")
+
+    @Test
+    func testAllWithAttributes() throws {
+        let dogElements = try exampleDocument.root["dogs"]["dog"]
+        let bulls = try #require(dogElements.all(withAttributes: ["color" : "white"]))
+        #expect(bulls.count == 2, "Should be able to return elements with given attributes.")
     }
-    
-    func testAllContainingAttributes() {
-        var count = 0
-        if let bulls = exampleDocument.root["dogs"]["dog"].all(containingAttributeKeys: ["gender"]) {
-            for _ in bulls {
-                count += 1
-            }
-        }
-        XCTAssertEqual(count, 2, "Should be able to return elements with given attribute keys.")
+
+    @Test
+    func testAllContainingAttributes() throws {
+        let dogElements = try exampleDocument.root["dogs"]["dog"]
+        let bulls = try #require(dogElements.all(containingAttributeKeys: ["gender"]))
+        #expect(bulls.count == 2, "Should be able to return elements with given attribute keys.")
     }
-    
+
+    @Test
     func testAllDescendantsWherePredicate() {
         let children = exampleDocument.allDescendants { $0.attributes["color"] == "yellow" }
-        
-        XCTAssertEqual(children.count, 2, "Should be able to return elements matching predicate.")
+
+        #expect(children.count == 2, "Should be able to return elements matching predicate.")
     }
-    
-    func testFirstDescendantWherePredicate() {
-        let descendant = plantsDocument.root.firstDescendant { $0.hasDescendant { $0.name == "LIGHT" && $0.value == "Sunny" } }
-        let plantName = descendant?["COMMON"].value
-        
-        XCTAssertEqual(plantName, "Black-Eyed Susan", "Should be able to find first child satisfying predicate.")
+
+    @Test
+    func testFirstDescendantWherePredicate() throws {
+        let descendant = try plantsDocument.root.firstDescendant { $0.hasDescendant { $0.name == "LIGHT" && $0.value == "Sunny" } }
+        let plantName = try descendant?["COMMON"].value
+
+        #expect(plantName == "Black-Eyed Susan", "Should be able to find first child satisfying predicate.")
     }
-    
+
+    @Test
     func testHasDescendantWherePredicate() {
         let hasDescendant = plantsDocument.hasDescendant { $0.name == "AVAILABILITY" && $0.int == 030699 }
-        
-        XCTAssert(hasDescendant, "Should be able to determine that document has a child satisfying predicate.")
+
+        #expect(hasDescendant, "Should be able to determine that document has a child satisfying predicate.")
     }
-    
-    func testSpecialCharacterTrimRead() {
+
+    @Test
+    func testSpecialCharacterTrimRead() throws {
         let expected = "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<elements>\n\t<string name=\"this_and_that\">This &amp; that</string>\n</elements>"
         
-        let readerDocument = try! AEXMLDocument(xml: expected)
+        let readerDocument = try AEXMLDocument(xml: expected)
         let readerXml = readerDocument.xml
-        XCTAssertEqual(readerXml, expected, "Should be able to print XML formatted string.")
+        #expect(readerXml == expected, "Should be able to print XML formatted string.")
     }
     
     // MARK: - XML Write
-    
-    func testAddChild() {
-        let ducks = exampleDocument.root.addChild(name: "ducks")
+
+    @Test
+    func testAddChild() throws {
+        let ducks = try exampleDocument.root.addChild(name: "ducks")
         ducks.addChild(name: "duck", value: "Donald")
         ducks.addChild(name: "duck", value: "Daisy")
         ducks.addChild(name: "duck", value: "Scrooge")
         
-        let animalsCount = exampleDocument.root.children.count
-        XCTAssertEqual(animalsCount, 3, "Should be able to add child elements to an element.")
-        XCTAssertEqual(exampleDocument.root["ducks"]["duck"].last!.string, "Scrooge", "Should be able to iterate ducks now.")
+        let animalsCount = try exampleDocument.root.children.count
+        #expect(animalsCount == 3, "Should be able to add child elements to an element.")
+
+        let resultDucks = try exampleDocument.root["ducks"]["duck"]
+        #expect(resultDucks.last?.string == "Scrooge", "Should be able to iterate ducks now.")
     }
-    
-    func testAddChildWithAttributes() {
-        let cats = exampleDocument.root["cats"]
-        let dogs = exampleDocument.root["dogs"]
-        
+
+    @Test
+    func testAddChildWithAttributes() throws {
+        let cats = try exampleDocument.root["cats"]
+        let dogs = try exampleDocument.root["dogs"]
+
         cats.addChild(name: "cat", value: "Garfield", attributes: ["breed" : "tabby", "color" : "orange"])
         dogs.addChild(name: "dog", value: "Snoopy", attributes: ["breed" : "beagle", "color" : "white"])
         
-        let catsCount = cats["cat"].count
-        let dogsCount = dogs["dog"].count
-        
-        let lastCat = cats["cat"].last!
+        let catsCount = try cats["cat"].count
+        let dogsCount = try dogs["dog"].count
+
+        let lastCat = try cats["cat"].last!
         let penultDog = dogs.children[3]
         
-        XCTAssertEqual(catsCount, 5, "Should be able to add child element with attributes to an element.")
-        XCTAssertEqual(dogsCount, 5, "Should be able to add child element with attributes to an element.")
-        
-        XCTAssertEqual(lastCat.attributes["color"], "orange", "Should be able to get attribute value from added element.")
-        XCTAssertEqual(penultDog.string, "Kika", "Should be able to add child with attributes without overwrites existing elements. (Github Issue #28)")
+        #expect(catsCount == 5, "Should be able to add child element with attributes to an element.")
+        #expect(dogsCount == 5, "Should be able to add child element with attributes to an element.")
+
+        #expect(lastCat.attributes["color"] == "orange", "Should be able to get attribute value from added element.")
+        #expect(penultDog.string == "Kika", "Should be able to add child with attributes without overwrites existing elements. (Github Issue #28)")
     }
-    
-    func testAddChildren() {
+
+    @Test
+    func testAddChildren() throws {
         let animals: [AEXMLElement] = [
             AEXMLElement(name: "dinosaurs"),
             AEXMLElement(name: "birds"),
             AEXMLElement(name: "bugs"),
         ]
-        exampleDocument.root.addChildren(animals)
-        
-        let animalsCount = exampleDocument.root.children.count
-        XCTAssertEqual(animalsCount, 5, "Should be able to add children elements to an element.")
+        try exampleDocument.root.addChildren(animals)
+
+        let animalsCount = try exampleDocument.root.children.count
+        #expect(animalsCount == 5, "Should be able to add children elements to an element.")
     }
-    
-    func testAddAttributes() {
-        let firstCat = exampleDocument.root["cats"]["cat"]
+
+    @Test
+    func testAddAttributes() throws {
+        let firstCat = try exampleDocument.root["cats"]["cat"]
 
         firstCat.attributes["funny"] = "true"
         firstCat.attributes["speed"] = "fast"
         firstCat.attributes["years"] = "7"
         
-        XCTAssertEqual(firstCat.attributes.count, 5, "Should be able to add attributes to an element.")
-        XCTAssertEqual(Int(firstCat.attributes["years"]!), 7, "Should be able to get any attribute value now.")
+        #expect(firstCat.attributes.count == 5, "Should be able to add attributes to an element.")
+
+        let firstCatYear = try #require(firstCat.attributes["years"])
+        #expect(Int(firstCatYear) == 7, "Should be able to get any attribute value now.")
     }
-    
-    func testRemoveChild() {
-        let cats = exampleDocument.root["cats"]
-        let lastCat = cats["cat"].last!
+
+    @Test
+    func testRemoveChild() throws {
+        let cats = try exampleDocument.root["cats"]
+        let lastCat = try cats["cat"].last!
         let duplicateCat = cats.addChild(name: "cat", value: "Tinna", attributes: ["breed" : "Siberian", "color" : "lightgray"])
         
         lastCat.removeFromParent()
         duplicateCat.removeFromParent()
         
-        let catsCount = cats["cat"].count
-        let firstCat = cats["cat"]
-        XCTAssertEqual(catsCount, 3, "Should be able to remove element from parent.")
-        XCTAssertEqual(firstCat.string, "Tinna", "Should be able to remove the exact element from parent.")
+        let catsCount = try cats["cat"].count
+        let firstCat = try cats["cat"]
+        #expect(catsCount == 3, "Should be able to remove element from parent.")
+        #expect(firstCat.string == "Tinna", "Should be able to remove the exact element from parent.")
     }
-    
+
+    @Test
     func testXMLEscapedString() {
         let string = "&<>'\""
         let escapedString = string.xmlEscaped
-        XCTAssertEqual(escapedString, "&amp;&lt;&gt;&apos;&quot;")
+        #expect(escapedString == "&amp;&lt;&gt;&apos;&quot;")
     }
-    
+
+    @Test
     func testXMLString() {
         let testDocument = AEXMLDocument()
         let children = testDocument.addChild(name: "children")
@@ -470,29 +462,34 @@ class AEXMLTests: XCTestCase {
         children.addChild(name: "child")
         children.addChild(name: "child", value: "&<>'\"\n")
         
-        XCTAssertEqual(testDocument.xml, "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<children>\n\t<child attribute=\"attributeValue&lt;&amp;&gt;\">value</child>\n\t<child />\n\t<child>&amp;&lt;&gt;&apos;&quot;&#10;</child>\n</children>", "Should be able to print XML formatted string.")
-        
-        XCTAssertEqual(testDocument.xmlCompact, "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?><children><child attribute=\"attributeValue&lt;&amp;&gt;\">value</child><child /><child>&amp;&lt;&gt;&apos;&quot;&#10;</child></children>", "Should be able to print compact XML string.")
-        
-        XCTAssertEqual(testDocument.xmlSpaces, "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<children>\n    <child attribute=\"attributeValue&lt;&amp;&gt;\">value</child>\n    <child />\n    <child>&amp;&lt;&gt;&apos;&quot;&#10;</child>\n</children>", "Should be able to print XML formatted string.")
-        
-        XCTAssertEqual(testDocument.xmlDoubleSpace, "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<children>\n  <child attribute=\"attributeValue&lt;&amp;&gt;\">value</child>\n  <child />\n  <child>&amp;&lt;&gt;&apos;&quot;&#10;</child>\n</children>", "Should be able to print XML formatted string.")
+        #expect(testDocument.xml == "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<children>\n\t<child attribute=\"attributeValue&lt;&amp;&gt;\">value</child>\n\t<child />\n\t<child>&amp;&lt;&gt;&apos;&quot;&#10;</child>\n</children>", "Should be able to print XML formatted string.")
+
+        #expect(testDocument.xmlCompact == "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?><children><child attribute=\"attributeValue&lt;&amp;&gt;\">value</child><child /><child>&amp;&lt;&gt;&apos;&quot;&#10;</child></children>", "Should be able to print compact XML string.")
+
+        #expect(testDocument.xmlSpaces == "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<children>\n    <child attribute=\"attributeValue&lt;&amp;&gt;\">value</child>\n    <child />\n    <child>&amp;&lt;&gt;&apos;&quot;&#10;</child>\n</children>", "Should be able to print XML formatted string.")
+
+        #expect(testDocument.xmlDoubleSpace == "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>\n<children>\n  <child attribute=\"attributeValue&lt;&amp;&gt;\">value</child>\n  <child />\n  <child>&amp;&lt;&gt;&apos;&quot;&#10;</child>\n</children>", "Should be able to print XML formatted string.")
     }
     
     // MARK: - XML Parse Performance
-    
+
+    // TODO: SwiftTesting does not yet support benchmark testing
+
+    /*
+    @Test
     func testReadXMLPerformance() {
         self.measure() {
             _ = self.readXMLFromFile(filename: "plant_catalog")
         }
     }
-    
+
+    @Test
     func testWriteXMLPerformance() {
         self.measure() {
             _ = self.plantsDocument.xml
         }
     }
-    
+    */
 }
 
 #if XCODE

--- a/Tests/AEXMLTests/AEXMLTests.swift
+++ b/Tests/AEXMLTests/AEXMLTests.swift
@@ -267,7 +267,7 @@ class AEXMLTests {
     @Test
     func testNotExistingElement() {
         // non-optional
-        #expect(throws: AEXMLError.elementNotFound) {
+        #expect(throws: AEXMLError.elementNotFound("ducks")) {
             try exampleDocument.root["ducks"]["duck"]
         }
 


### PR DESCRIPTION
Seeking out errors from `AEXMLElement.error` always seemed unintuitive to me, where throwing functions are the more idiomatic Swift way to handle this. So here is a pull request that removes the `error` property, and instead makes the places where existing errors could be created into throwing functions.

This is a breaking change, of course, since it changes the call signature of the following:

- `AEXMLDocument.root` Getter now throws `AEXMLError.rootElementMissing` if no root element exists (previously, this would return an empty `AEXMLElement` with the error stored in its `error` property).
- `AEXMLElement["key"] getter now throws `AEXMLError.elementNotFound(String)` if the element with the given name is not found (previously, this would also return an empty element with an error property).

Extra changes I made:

- Updated Unit Tests to Swift Testing
- `AEXMLError.elementNotFound` now includes the key that wasn't found, so you can chain subscripts together and know which one failed, like so:
```
// this throws AEXMLError.elementNotFound("badKey1")
let x = try element["goodKey"]["badKey1"]["badKey2"]
```

Hope you like it. Thanks for creating this library!