### PR TITLE
Bump deployment target to watchOS 9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .iOS(.v12),
         .macOS(.v10_13),
         .tvOS(.v12),
-        .watchOS(.v4)
+        .watchOS(.v9)
     ],
     products: [
         .library(


### PR DESCRIPTION
Xcode 27 (Beta 4) and Swift 6.4 are reporting a warning about missing watchOS v4 support:

> 'v4' is deprecated: watchOS 9.0 is the oldest supported version

I thought about how you could release it. If you are not planning any more updates until Xcode 27 drops in a few weeks, a `4.7.1` update would be great.

If other developers need the v4 support going forward, they will be stuck on Xcode 26 or lower with `4.7.0` anyways.